### PR TITLE
Don't read recursive when getting profile names.

### DIFF
--- a/calico_containers/pycalico/datastore.py
+++ b/calico_containers/pycalico/datastore.py
@@ -474,8 +474,7 @@ class DatastoreClient(object):
         """
         profiles = set()
         try:
-            etcd_profiles = self.etcd_client.read(PROFILES_PATH,
-                                                  recursive=True).children
+            etcd_profiles = self.etcd_client.read(PROFILES_PATH).children
             for child in etcd_profiles:
                 packed = child.key.split("/")
                 if len(packed) > 5:

--- a/calico_containers/tests/unit/datastore_test.py
+++ b/calico_containers/tests/unit/datastore_test.py
@@ -1537,15 +1537,10 @@ def mock_read_no_node_bgppeers(path):
     return result
 
 
-def mock_read_2_profiles(path, recursive):
+def mock_read_2_profiles(path):
     assert path == ALL_PROFILES_PATH
-    assert recursive
     nodes = [CALICO_V_PATH + "/policy/profile/TEST",
-             CALICO_V_PATH + "/policy/profile/TEST/tags",
-             CALICO_V_PATH + "/policy/profile/TEST/rules",
-             CALICO_V_PATH + "/policy/profile/UNIT",
-             CALICO_V_PATH + "/policy/profile/UNIT/tags",
-             CALICO_V_PATH + "/policy/profile/UNIT/rules"]
+             CALICO_V_PATH + "/policy/profile/UNIT"]
     children = []
     for node in nodes:
         result = Mock(spec=EtcdResult)
@@ -1556,17 +1551,15 @@ def mock_read_2_profiles(path, recursive):
     return results
 
 
-def mock_read_no_profiles(path, recursive):
+def mock_read_no_profiles(path):
     assert path == ALL_PROFILES_PATH
-    assert recursive
     results = Mock(spec=EtcdResult)
     results.children = iter([])
     return results
 
 
-def mock_read_profiles_key_error(path, recursive):
+def mock_read_profiles_key_error(path):
     assert path == ALL_PROFILES_PATH
-    assert recursive
     raise EtcdKeyNotFound()
 
 


### PR DESCRIPTION
Noticed this while working on IPAM.  We don't need to recurse into the rules and tags for profiles to get their names.
