### PR TITLE
Correct duplicate test name

### DIFF
--- a/calico_containers/tests/unit/test_util.py
+++ b/calico_containers/tests/unit/test_util.py
@@ -154,7 +154,7 @@ class TestUtil(unittest.TestCase):
                                   'fe80::188f:d6ff:fe1f:1482'])
 
     @patch("pycalico.util.check_output", autospec=True)
-    def test_get_host_ips_exclude_docker(self, m_check_output):
+    def test_get_host_ips_exclude_docker_prefix(self, m_check_output):
         '''Test get_host_ips exclude "docker0.*'''
         # Test IPv4
         m_check_output.return_value = MOCK_IP_ADDR_DOCKER_NONE


### PR DESCRIPTION
There were two tests in this file named `test_get_host_ips_exclude_docker`, which meant that the first test would never run.

The quick-and-easy fix is to rename one of the tests, which is what I've done. Somebody who knows the tests better than me should probably check:
1. Whether we actually want both tests (they're similar but not identical)
2. If so, whether I've chosen an appropriate name
