### PR TITLE
Lockdown python-etcd version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ sh==1.11
 coveralls
 netaddr==0.7.15
 subprocess32
-git+https://github.com/projectcalico/python-etcd.git
+git+https://github.com/projectcalico/python-etcd.git@0.4.1+calico.1


### PR DESCRIPTION
Guarentee stability of dependency list
