### PR TITLE
Remove unused imports

### DIFF
--- a/calico_containers/pycalico/ipam.py
+++ b/calico_containers/pycalico/ipam.py
@@ -16,7 +16,6 @@ from etcd import EtcdKeyNotFound, EtcdAlreadyExist, EtcdCompareFailed
 
 from netaddr import IPAddress, IPNetwork
 import socket
-import uuid
 import logging
 import random
 

--- a/calico_containers/pycalico/util.py
+++ b/calico_containers/pycalico/util.py
@@ -1,6 +1,6 @@
 import sys
 import re
-from netaddr import IPNetwork, AddrFormatError
+from netaddr import IPNetwork
 from subprocess import check_output, CalledProcessError
 
 """

--- a/calico_containers/tests/unit/block_test.py
+++ b/calico_containers/tests/unit/block_test.py
@@ -14,7 +14,7 @@
 from netaddr import IPNetwork, IPAddress
 from nose.tools import *
 from nose_parameterized import parameterized
-from mock import patch, ANY, call, Mock
+from mock import patch, Mock
 import unittest
 import json
 from pycalico.block import (AllocationBlock,

--- a/calico_containers/tests/unit/handle_test.py
+++ b/calico_containers/tests/unit/handle_test.py
@@ -11,10 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from netaddr import IPNetwork, IPAddress
+from netaddr import IPNetwork
 from nose.tools import *
-from nose_parameterized import parameterized
-from mock import patch, ANY, call, Mock
+from mock import Mock
 import unittest
 import json
 from pycalico.handle import (AllocationHandle, AddressCountTooLow)

--- a/calico_containers/tests/unit/netns_test.py
+++ b/calico_containers/tests/unit/netns_test.py
@@ -16,7 +16,7 @@ import os
 import unittest
 
 from nose.tools import *
-from mock import patch, Mock, call, ANY
+from mock import patch, call, ANY
 
 from pycalico.netns import (create_veth, remove_veth, veth_exists,
                             IP_CMD_TIMEOUT, CalledProcessError)


### PR DESCRIPTION
I ran flake8 over the repo and picked out reports of unused imports.

I also ran the tests to ensure I hadn't broken anything.
