### PR TITLE
Removed use of check_call in netns and improved logging

### DIFF
--- a/calico_containers/tests/unit/netns_test.py
+++ b/calico_containers/tests/unit/netns_test.py
@@ -24,41 +24,41 @@ from pycalico.netns import (create_veth, remove_veth, veth_exists,
 
 class TestVeth(unittest.TestCase):
 
-    @patch("pycalico.netns.check_call", autospec=True)
-    def test_create_veth(self, m_check_call):
+    @patch("pycalico.netns.check_output", autospec=True)
+    def test_create_veth(self, m_check_output):
         """
         Test creating a veth (pair).
         """
         create_veth("veth1", "temp_name")
-        check_call_1 = call(['ip', 'link', 'add', "veth1", 'type',
+        check_output_1 = call(['ip', 'link', 'add', "veth1", 'type',
                              'veth','peer', 'name', "temp_name"],
                             timeout=IP_CMD_TIMEOUT)
-        check_call_2 = call(['ip', 'link', 'set', "veth1", 'up'],
+        check_output_2 = call(['ip', 'link', 'set', "veth1", 'up'],
                             timeout=IP_CMD_TIMEOUT)
-        m_check_call.assert_has_calls([check_call_1, check_call_2])
+        m_check_output.assert_has_calls([check_output_1, check_output_2])
 
     @patch("pycalico.netns.veth_exists", autospec=True)
-    @patch("pycalico.netns.check_call", autospec=True)
-    def test_remove_veth_success(self, m_check_call, m_veth_exists):
+    @patch("pycalico.netns.check_output", autospec=True)
+    def test_remove_veth_success(self, m_check_output, m_veth_exists):
         """
         Test remove_veth returns True for successfully removing a veth.
         """
         m_veth_exists.return_value = True;
         self.assertTrue(remove_veth("veth1"))
         m_veth_exists.assert_called_once_with("veth1")
-        m_check_call.assert_called_once_with(['ip', 'link', 'del', "veth1"],
+        m_check_output.assert_called_once_with(['ip', 'link', 'del', "veth1"],
                                              timeout=IP_CMD_TIMEOUT)
 
     @patch("pycalico.netns.veth_exists", autospec=True)
-    @patch("pycalico.netns.check_call", autospec=True)
-    def test_remove_veth_no_veth(self, m_check_call, m_veth_exists):
+    @patch("pycalico.netns.check_output", autospec=True)
+    def test_remove_veth_no_veth(self, m_check_output, m_veth_exists):
         """
         Test remove_veth returns False when veth doesn't exist.
         """
         m_veth_exists.return_value = False;
         self.assertFalse(remove_veth("veth1"))
         m_veth_exists.assert_called_once_with("veth1")
-        self.assertFalse(m_check_call.called)
+        self.assertFalse(m_check_output.called)
 
     @patch('__builtin__.open', autospec=True)
     @patch("pycalico.netns.check_call", autospec=True)


### PR DESCRIPTION
Replaced `check_call` with `check_output`, which, when its call throws an exception, will include  a `.output` field which grabs stdout and can be used to better log and debug encountered errors
