### PR TITLE
Update remove_host to delete IPAM blocks for host

### DIFF
--- a/calico_containers/pycalico/datastore.py
+++ b/calico_containers/pycalico/datastore.py
@@ -90,7 +90,8 @@ IP_IN_IP_ENABLED = "true"
 
 # IPAM paths
 IPAM_V_PATH = "/calico/ipam/v2/"
-IPAM_HOST_PATH = IPAM_V_PATH + "host/%(hostname)s/"
+IPAM_HOSTS_PATH = IPAM_V_PATH + "host/"
+IPAM_HOST_PATH = IPAM_HOSTS_PATH + "%(hostname)s/"
 IPAM_HOST_AFFINITY_PATH = IPAM_HOST_PATH + "ipv%(version)d/block/"
 IPAM_BLOCK_PATH = IPAM_V_PATH + "assignment/ipv%(version)d/block/"
 IPAM_HANDLE_PATH = IPAM_V_PATH + "handle/"
@@ -242,6 +243,13 @@ class DatastoreClient(object):
         bgp_host_path = BGP_HOST_PATH % {"hostname": hostname}
         try:
             self.etcd_client.delete(bgp_host_path, dir=True, recursive=True)
+        except EtcdKeyNotFound:
+            pass
+
+        # Remove the IPAM host tree.
+        ipam_host_path = IPAM_HOST_PATH % {"hostname": hostname}
+        try:
+            self.etcd_client.delete(ipam_host_path, dir=True, recursive=True)
         except EtcdKeyNotFound:
             pass
 

--- a/calico_containers/tests/unit/datastore_test.py
+++ b/calico_containers/tests/unit/datastore_test.py
@@ -56,6 +56,7 @@ CONFIG_PATH = CALICO_V_PATH + "/config/"
 BGP_V_PATH = "/calico/bgp/v1"
 BGP_GLOBAL_PATH = BGP_V_PATH + "/global"
 TEST_BGP_HOST_PATH = BGP_V_PATH + "/host/TEST_HOST"
+TEST_IPAM_HOST_PATH = "/calico/ipam/v2/host/TEST_HOST"
 BGP_PEERS_PATH = BGP_GLOBAL_PATH + "/peer_v4/"
 TEST_NODE_BGP_PEERS_PATH = TEST_BGP_HOST_PATH + "/peer_v4/"
 BGP_NODE_DEF_AS_PATH = BGP_GLOBAL_PATH + "/as_num"
@@ -871,6 +872,9 @@ class TestDatastoreClient(unittest.TestCase):
         """
         self.datastore.remove_host(TEST_HOST)
         expected_deletes = [call(TEST_BGP_HOST_PATH + "/",
+                                 dir=True,
+                                 recursive=True),
+                            call(TEST_IPAM_HOST_PATH + "/",
                                  dir=True,
                                  recursive=True),
                             call(TEST_HOST_PATH + "/",


### PR DESCRIPTION
- Help fix projectcalico/calico-docker#519: calicoctl node stop does not release IPAM allocation for host
- Use BGP Path format for IPAM Path constant
