### PR TITLE
Add support for secure etcd

### DIFF
--- a/calico_containers/pycalico/datastore.py
+++ b/calico_containers/pycalico/datastore.py
@@ -147,25 +147,24 @@ class DatastoreClient(object):
                                                 ETCD_KEY_FILE_ENV, etcd_key,
                                                 ETCD_CERT_FILE_ENV, etcd_cert))
             # Make sure etcd key and certificate are readable
-            if etcd_key and etcd_cert:
-                if not (os.path.isfile(etcd_key) and
-                        os.access(etcd_key, os.R_OK) and
-                        os.path.isfile(etcd_cert) and
-                        os.access(etcd_cert, os.R_OK)):
-                    raise DataStoreError("Cannot read %s and/or %s. Both must "
-                                         "be readable file paths. Values "
-                                         "provided: %s=%s, %s=%s" %
-                                         (ETCD_KEY_FILE_ENV,
-                                          ETCD_CERT_FILE_ENV,
-                                          ETCD_KEY_FILE_ENV, etcd_key,
-                                          ETCD_CERT_FILE_ENV, etcd_cert))
-                # If Certificate Authority cert provided, check it's readable
-                if etcd_ca and not (os.path.isfile(etcd_ca) and
-                                    os.access(etcd_ca, os.R_OK)):
-                    raise DataStoreError("Cannot read %s. Value must be "
-                                         "readable file path. Value provided: "
-                                         "%s" % (ETCD_CA_CERT_FILE_ENV,
-                                                 etcd_ca))
+            if etcd_key and etcd_cert and not (os.path.isfile(etcd_key) and
+                                               os.access(etcd_key, os.R_OK) and
+                                               os.path.isfile(etcd_cert) and
+                                               os.access(etcd_cert, os.R_OK)):
+                raise DataStoreError("Cannot read %s and/or %s. Both must "
+                                     "be readable file paths. Values "
+                                     "provided: %s=%s, %s=%s" %
+                                     (ETCD_KEY_FILE_ENV,
+                                      ETCD_CERT_FILE_ENV,
+                                      ETCD_KEY_FILE_ENV, etcd_key,
+                                      ETCD_CERT_FILE_ENV, etcd_cert))
+            # Certificate Authority cert must be provided, check it's readable
+            if not etcd_ca or not (os.path.isfile(etcd_ca) and
+                                   os.access(etcd_ca, os.R_OK)):
+                raise DataStoreError("Invalid %s. Certificate Authority "
+                                     "cert is required and must be a "
+                                     "readable file path. Value provided: "
+                                     "%s" % (ETCD_CA_CERT_FILE_ENV, etcd_ca))
         elif etcd_scheme != "http":
             raise DataStoreError("Invalid %s. Value must be one of: \"\", "
                                  "\"http\", \"https\". Value provided: %s" %

--- a/calico_containers/pycalico/datastore.py
+++ b/calico_containers/pycalico/datastore.py
@@ -29,6 +29,16 @@ from pycalico.util import get_hostname
 ETCD_AUTHORITY_DEFAULT = "127.0.0.1:2379"
 ETCD_AUTHORITY_ENV = "ETCD_AUTHORITY"
 
+# Secure etcd with SSL environment variables and paths
+ETCD_SCHEME_DEFAULT = "http"
+ETCD_SCHEME_ENV = "ETCD_SCHEME_ENV"
+ETCD_KEY_FILE_ENV = "ETCD_KEY_FILE"
+ETCD_KEY_NODE_FILE = "/etc/calico/ssl/key.pem"
+ETCD_CERT_FILE_ENV = "ETCD_CERT_FILE"
+ETCD_CERT_NODE_FILE = "/etc/calico/ssl/cert.crt"
+ETCD_CA_CERT_FILE_ENV = "ETCD_CA_CERT_FILE"
+ETCD_CA_CERT_NODE_FILE = "/etc/calico/ssl/ca_cert.crt"
+
 # etcd paths for Calico workloads, endpoints and IPAM.
 CALICO_V_PATH = "/calico/v1"
 CONFIG_PATH = CALICO_V_PATH + "/config/"
@@ -113,6 +123,51 @@ def handle_errors(fn):
     return wrapped
 
 
+def assert_valid_etcd_keys(scheme, key, cert, ca_cert):
+    """
+    Validate etcd SSL environment variables set on the host machine.  The key
+    and certificate values must both be set or not set.  All values passed
+    in must be readable.
+
+    Raise a DataStoreError if any assertions fail.
+
+    :param scheme: HTTP protocol type. One of: "", "http", or "https"
+    :param key: Path to secure key for etcd or None value
+    :param cert: Path to secure certificate for etcd or None value
+    :param ca_cert: Path to Certificate Authority signing certificate for etcd
+    of None value
+    """
+    if scheme == "https":
+        # etcd key and certificate must be both specified or both not specified
+        if bool(key) != bool(cert):
+            raise DataStoreError("Invalid %s, %s combination. Key and "
+                                 "certificate must both be specified or both "
+                                 "be blank. Values provided: %s=%s, %s=%s" %
+                                 (ETCD_KEY_FILE_ENV, ETCD_CERT_FILE_ENV,
+                                  ETCD_KEY_FILE_ENV, key,
+                                  ETCD_CERT_FILE_ENV, cert))
+        # Make sure etcd key and certificate are readable
+        if key and cert:
+            if not (os.access(key, os.R_OK) and os.access(cert, os.R_OK)):
+                raise DataStoreError("Cannot read %s and/or %s. Both must be "
+                                     "readable file paths. Values provided: "
+                                     "%s=%s, %s=%s" % (ETCD_KEY_FILE_ENV,
+                                                       ETCD_CERT_FILE_ENV,
+                                                       ETCD_KEY_FILE_ENV,
+                                                       key,
+                                                       ETCD_CERT_FILE_ENV,
+                                                       cert))
+            # If Certificate Authority cert file provided, check it's readable
+            if ca_cert and not os.access(ca_cert, os.R_OK):
+                raise DataStoreError("Cannot read %s. Value must be readable "
+                                     "file path. Value provided: %s" %
+                                     (ETCD_CA_CERT_FILE_ENV, ca_cert))
+    elif not (scheme == "http" or scheme == ""):
+        raise DataStoreError("Invalid %s. Value must be one of: \"\", "
+                             "\"http\", \"https\". Value provided: %s" %
+                             (ETCD_SCHEME_ENV, scheme))
+
+
 class DatastoreClient(object):
     """
     An datastore client that exposes high level Calico operations needed by the
@@ -122,8 +177,20 @@ class DatastoreClient(object):
     def __init__(self):
         etcd_authority = os.getenv(ETCD_AUTHORITY_ENV, ETCD_AUTHORITY_DEFAULT)
         (host, port) = etcd_authority.split(":", 1)
+
+        etcd_scheme = os.getenv(ETCD_SCHEME_ENV, ETCD_SCHEME_DEFAULT)
+        etcd_key = os.getenv(ETCD_KEY_FILE_ENV, '')
+        etcd_cert = os.getenv(ETCD_CERT_FILE_ENV, '')
+        etcd_ca = os.getenv(ETCD_CA_CERT_FILE_ENV, '')
+        key_pair = (etcd_cert, etcd_key)
+
+        assert_valid_etcd_keys(etcd_scheme, etcd_key, etcd_cert, etcd_ca)
+
         self.etcd_client = etcd.Client(host=host,
-                                       port=int(port))
+                                       port=int(port),
+                                       protocol=etcd_scheme,
+                                       cert=key_pair,
+                                       ca_cert=etcd_ca)
 
     @handle_errors
     def ensure_global_config(self):

--- a/calico_containers/pycalico/datastore.py
+++ b/calico_containers/pycalico/datastore.py
@@ -148,8 +148,10 @@ class DatastoreClient(object):
                                                 ETCD_CERT_FILE_ENV, etcd_cert))
             # Make sure etcd key and certificate are readable
             if etcd_key and etcd_cert:
-                if not (os.access(etcd_key, os.R_OK) and
-                            os.access(etcd_cert, os.R_OK)):
+                if not (os.path.isfile(etcd_key) and
+                        os.access(etcd_key, os.R_OK) and
+                        os.path.isfile(etcd_cert) and
+                        os.access(etcd_cert, os.R_OK)):
                     raise DataStoreError("Cannot read %s and/or %s. Both must "
                                          "be readable file paths. Values "
                                          "provided: %s=%s, %s=%s" %
@@ -158,7 +160,8 @@ class DatastoreClient(object):
                                           ETCD_KEY_FILE_ENV, etcd_key,
                                           ETCD_CERT_FILE_ENV, etcd_cert))
                 # If Certificate Authority cert provided, check it's readable
-                if etcd_ca and not os.access(etcd_ca, os.R_OK):
+                if etcd_ca and not (os.path.isfile(etcd_ca) and
+                                    os.access(etcd_ca, os.R_OK)):
                     raise DataStoreError("Cannot read %s. Value must be "
                                          "readable file path. Value provided: "
                                          "%s" % (ETCD_CA_CERT_FILE_ENV,
@@ -168,6 +171,8 @@ class DatastoreClient(object):
                                  "\"http\", \"https\". Value provided: %s" %
                                  (ETCD_SCHEME_ENV, etcd_scheme))
 
+        # Set CA value to None if it is a None-value string
+        etcd_ca = None if not etcd_ca else etcd_ca
         self.etcd_client = etcd.Client(host=host,
                                        port=int(port),
                                        protocol=etcd_scheme,

--- a/calico_containers/pycalico/datastore.py
+++ b/calico_containers/pycalico/datastore.py
@@ -134,6 +134,10 @@ class DatastoreClient(object):
         etcd_key = os.getenv(ETCD_KEY_FILE_ENV, '')
         etcd_cert = os.getenv(ETCD_CERT_FILE_ENV, '')
         etcd_ca = os.getenv(ETCD_CA_CERT_FILE_ENV, '')
+        print "etcd_scheme is %s" % etcd_scheme
+        print "etcd_key is %s" % etcd_key
+        print "etcd_cert is %s" % etcd_cert
+        print "etcd_ca is %s" % etcd_ca
         key_pair = (etcd_cert, etcd_key) if (etcd_cert and etcd_key) else None
 
         if etcd_scheme == "https":

--- a/calico_containers/pycalico/datastore.py
+++ b/calico_containers/pycalico/datastore.py
@@ -25,11 +25,6 @@ from pycalico.datastore_datatypes import Rules, BGPPeer, IPPool, \
 from pycalico.datastore_errors import DataStoreError, \
     ProfileNotInEndpoint, ProfileAlreadyInEndpoint, MultipleEndpointsMatch
 from pycalico.util import get_hostname
-import logging
-
-# Suppress warnings from urllib3 when etcd is used without CA cert.
-logging.captureWarnings(True)
-_log = logging.getLogger(__name__)
 
 ETCD_AUTHORITY_DEFAULT = "127.0.0.1:2379"
 ETCD_AUTHORITY_ENV = "ETCD_AUTHORITY"

--- a/calico_containers/pycalico/datastore.py
+++ b/calico_containers/pycalico/datastore.py
@@ -25,6 +25,11 @@ from pycalico.datastore_datatypes import Rules, BGPPeer, IPPool, \
 from pycalico.datastore_errors import DataStoreError, \
     ProfileNotInEndpoint, ProfileAlreadyInEndpoint, MultipleEndpointsMatch
 from pycalico.util import get_hostname
+import logging
+
+# Suppress warnings from urllib3 when etcd is used without CA cert.
+logging.captureWarnings(True)
+_log = logging.getLogger(__name__)
 
 ETCD_AUTHORITY_DEFAULT = "127.0.0.1:2379"
 ETCD_AUTHORITY_ENV = "ETCD_AUTHORITY"

--- a/calico_containers/pycalico/datastore.py
+++ b/calico_containers/pycalico/datastore.py
@@ -134,10 +134,6 @@ class DatastoreClient(object):
         etcd_key = os.getenv(ETCD_KEY_FILE_ENV, '')
         etcd_cert = os.getenv(ETCD_CERT_FILE_ENV, '')
         etcd_ca = os.getenv(ETCD_CA_CERT_FILE_ENV, '')
-        print "etcd_scheme is %s" % etcd_scheme
-        print "etcd_key is %s" % etcd_key
-        print "etcd_cert is %s" % etcd_cert
-        print "etcd_ca is %s" % etcd_ca
         key_pair = (etcd_cert, etcd_key) if (etcd_cert and etcd_key) else None
 
         if etcd_scheme == "https":

--- a/calico_containers/tests/unit/datastore_test.py
+++ b/calico_containers/tests/unit/datastore_test.py
@@ -21,6 +21,7 @@ from pycalico import netns
 from mock import ANY
 from netaddr import IPNetwork, IPAddress, AddrFormatError
 from nose.tools import *
+from nose_parameterized import parameterized
 from mock import patch, Mock, call
 
 from pycalico.datastore import (DatastoreClient, CALICO_V_PATH,
@@ -1682,6 +1683,238 @@ class TestDatastoreClient(unittest.TestCase):
         self.etcd_client.read.side_effect = EtcdKeyNotFound
 
         assert_raises(KeyError, self.datastore.get_host_bgp_ips, TEST_HOST)
+
+
+class TestSecureDatastoreClient(unittest.TestCase):
+
+    @patch("pycalico.datastore.os.getenv", autospec=True)
+    @patch("pycalico.datastore.etcd.Client", autospec=True)
+    @patch("pycalico.datastore.os.access", autospec=True)
+    @patch("pycalico.datastore.os.path.isfile", autospec=True)
+    def test_secure_etcd_no_ca(self, m_isfile, m_access, m_etcd_client,
+                               m_getenv):
+        """ Test validation for secure etcd with no CA file. """
+        m_isfile.return_value = True
+        m_access.return_value = True
+        key_file = "/path/to/key_file"
+        cert_file = "/path/to/cert_file"
+        etcd_env_dict = {
+            ETCD_AUTHORITY_ENV   : "127.0.1.1:2380",
+            ETCD_SCHEME_ENV      : "https",
+            ETCD_KEY_FILE_ENV    : key_file,
+            ETCD_CERT_FILE_ENV   : cert_file,
+            ETCD_CA_CERT_FILE_ENV: ""
+        }
+
+        def m_getenv_return(key, *args):
+            return etcd_env_dict[key]
+        m_getenv.side_effect = m_getenv_return
+        self.etcd_client = Mock(spec=EtcdClient)
+        m_etcd_client.return_value = self.etcd_client
+        self.datastore = DatastoreClient()
+        m_etcd_client.assert_called_once_with(host="127.0.1.1",
+                                              port=2380,
+                                              protocol="https",
+                                              cert=(cert_file, key_file),
+                                              ca_cert=None)
+
+    @patch("pycalico.datastore.os.getenv", autospec=True)
+    @patch("pycalico.datastore.etcd.Client", autospec=True)
+    @patch("pycalico.datastore.os.access", autospec=True)
+    @patch("pycalico.datastore.os.path.isfile", autospec=True)
+    def test_secure_etcd_ca(self, m_isfile, m_access, m_etcd_client, m_getenv):
+        """ Test validation for secure etcd with a CA file. """
+        m_isfile.return_value = True
+        m_access.return_value = True
+        key_file = "/path/to/key_file"
+        cert_file = "/path/to/cert_file"
+        ca_file = "/path/to/ca_file"
+        etcd_env_dict = {
+            ETCD_AUTHORITY_ENV   : "127.0.1.1:2380",
+            ETCD_SCHEME_ENV      : "https",
+            ETCD_KEY_FILE_ENV    : key_file,
+            ETCD_CERT_FILE_ENV   : cert_file,
+            ETCD_CA_CERT_FILE_ENV: ca_file
+        }
+
+        def m_getenv_return(key, *args):
+            return etcd_env_dict[key]
+        m_getenv.side_effect = m_getenv_return
+        self.etcd_client = Mock(spec=EtcdClient)
+        m_etcd_client.return_value = self.etcd_client
+        self.datastore = DatastoreClient()
+        m_etcd_client.assert_called_once_with(host="127.0.1.1",
+                                              port=2380,
+                                              protocol="https",
+                                              cert=(cert_file, key_file),
+                                              ca_cert=ca_file)
+
+    @patch("pycalico.datastore.os.getenv", autospec=True)
+    @patch("pycalico.datastore.etcd.Client", autospec=True)
+    @patch("pycalico.datastore.os.access", autospec=True)
+    @patch("pycalico.datastore.os.path.isfile", autospec=True)
+    def test_secure_etcd_bad_scheme(self, m_isfile, m_access,
+                                    m_etcd_client, m_getenv):
+        """
+        Test validation for secure etcd fails when scheme is unrecognized.
+        """
+        m_isfile.return_value = True
+        m_access.return_value = True
+        etcd_env_dict = {
+            ETCD_AUTHORITY_ENV   : "127.0.1.1:2380",
+            ETCD_SCHEME_ENV      : "htt",
+            ETCD_KEY_FILE_ENV    : "",
+            ETCD_CERT_FILE_ENV   : "",
+            ETCD_CA_CERT_FILE_ENV: ""
+        }
+
+        def m_getenv_return(key, *args):
+            return etcd_env_dict[key]
+        m_getenv.side_effect = m_getenv_return
+        self.etcd_client = Mock(spec=EtcdClient)
+        m_etcd_client.return_value = self.etcd_client
+        self.assertRaises(DataStoreError, DatastoreClient)
+        self.assertFalse(m_etcd_client.called)
+
+    @patch("pycalico.datastore.os.getenv", autospec=True)
+    @patch("pycalico.datastore.etcd.Client", autospec=True)
+    @patch("pycalico.datastore.os.access", autospec=True)
+    @patch("pycalico.datastore.os.path.isfile", autospec=True)
+    def test_secure_etcd_missing_cert(self, m_isfile, m_access,
+                                      m_etcd_client, m_getenv):
+        """
+        Test validation for secure etcd fails when key is given but cert is
+        not.
+        """
+        m_isfile.return_value = True
+        m_access.return_value = True
+        etcd_env_dict = {
+            ETCD_AUTHORITY_ENV   : "127.0.1.1:2380",
+            ETCD_SCHEME_ENV      : "https",
+            ETCD_KEY_FILE_ENV    : "/path/to/key_file",
+            ETCD_CERT_FILE_ENV   : "",
+            ETCD_CA_CERT_FILE_ENV: ""
+        }
+
+        def m_getenv_return(key, *args):
+            return etcd_env_dict[key]
+        m_getenv.side_effect = m_getenv_return
+        self.etcd_client = Mock(spec=EtcdClient)
+        m_etcd_client.return_value = self.etcd_client
+        self.assertRaises(DataStoreError, DatastoreClient)
+        self.assertFalse(m_etcd_client.called)
+
+    @patch("pycalico.datastore.os.getenv", autospec=True)
+    @patch("pycalico.datastore.etcd.Client", autospec=True)
+    @patch("pycalico.datastore.os.access", autospec=True)
+    @patch("pycalico.datastore.os.path.isfile", autospec=True)
+    def test_secure_etcd_missing_key(self, m_isfile, m_access,
+                                     m_etcd_client, m_getenv):
+        """
+        Test validation for secure etcd fails when cert is given but key is
+        not.
+        """
+        m_isfile.return_value = True
+        m_access.return_value = True
+        etcd_env_dict = {
+            ETCD_AUTHORITY_ENV   : "127.0.1.1:2380",
+            ETCD_SCHEME_ENV      : "https",
+            ETCD_KEY_FILE_ENV    : "",
+            ETCD_CERT_FILE_ENV   : "/path/to/cert_file",
+            ETCD_CA_CERT_FILE_ENV: ""
+        }
+
+        def m_getenv_return(key, *args):
+            return etcd_env_dict[key]
+        m_getenv.side_effect = m_getenv_return
+        self.etcd_client = Mock(spec=EtcdClient)
+        m_etcd_client.return_value = self.etcd_client
+        self.assertRaises(DataStoreError, DatastoreClient)
+        self.assertFalse(m_etcd_client.called)
+
+    @patch("pycalico.datastore.os.getenv", autospec=True)
+    @patch("pycalico.datastore.etcd.Client", autospec=True)
+    @patch("pycalico.datastore.os.access", autospec=True)
+    @patch("pycalico.datastore.os.path.isfile", autospec=True)
+    def test_secure_etcd_key_not_file(self, m_isfile, m_access,
+                                      m_etcd_client, m_getenv):
+        """
+        Test validation for secure etcd fails when key is not a file.
+        """
+        m_isfile.return_value = False
+        m_access.return_value = True
+        etcd_env_dict = {
+            ETCD_AUTHORITY_ENV   : "127.0.1.1:2380",
+            ETCD_SCHEME_ENV      : "https",
+            ETCD_KEY_FILE_ENV    : "/path/to/key_dir/",
+            ETCD_CERT_FILE_ENV   : "/path/to/cert_file",
+            ETCD_CA_CERT_FILE_ENV: "/path/to/ca_file"
+        }
+
+        def m_getenv_return(key, *args):
+            return etcd_env_dict[key]
+        m_getenv.side_effect = m_getenv_return
+
+        self.etcd_client = Mock(spec=EtcdClient)
+        m_etcd_client.return_value = self.etcd_client
+        self.assertRaises(DataStoreError, DatastoreClient)
+        self.assertFalse(m_etcd_client.called)
+
+    @patch("pycalico.datastore.os.getenv", autospec=True)
+    @patch("pycalico.datastore.etcd.Client", autospec=True)
+    @patch("pycalico.datastore.os.access", autospec=True)
+    @patch("pycalico.datastore.os.path.isfile", autospec=True)
+    def test_secure_etcd_cert_not_readable(self, m_isfile, m_access,
+                                           m_etcd_client, m_getenv):
+        """
+        Test validation for secure etcd fails when cert is not a readable.
+        """
+        m_isfile.return_value = True
+        m_access.side_effect = [True, False]
+        etcd_env_dict = {
+            ETCD_AUTHORITY_ENV   : "127.0.1.1:2380",
+            ETCD_SCHEME_ENV      : "https",
+            ETCD_KEY_FILE_ENV    : "/path/to/key_file",
+            ETCD_CERT_FILE_ENV   : "/path/to/bad_cert",
+            ETCD_CA_CERT_FILE_ENV: "/path/to/ca_file"
+        }
+
+        def m_getenv_return(key, *args):
+            return etcd_env_dict[key]
+        m_getenv.side_effect = m_getenv_return
+
+        self.etcd_client = Mock(spec=EtcdClient)
+        m_etcd_client.return_value = self.etcd_client
+        self.assertRaises(DataStoreError, DatastoreClient)
+        self.assertFalse(m_etcd_client.called)
+
+    @patch("pycalico.datastore.os.getenv", autospec=True)
+    @patch("pycalico.datastore.etcd.Client", autospec=True)
+    @patch("pycalico.datastore.os.access", autospec=True)
+    @patch("pycalico.datastore.os.path.isfile")
+    def test_secure_etcd_ca_not_file(self, m_isfile, m_access,
+                                     m_etcd_client, m_getenv):
+        """
+        Test validation for secure etcd fails when ca is not a file.
+        """
+        m_isfile.side_effect = [True, True, False]
+        m_access.return_value = True
+        etcd_env_dict = {
+            ETCD_AUTHORITY_ENV   : "127.0.1.1:2380",
+            ETCD_SCHEME_ENV      : "https",
+            ETCD_KEY_FILE_ENV    : "/path/to/key_file",
+            ETCD_CERT_FILE_ENV   : "/path/to/cert_file",
+            ETCD_CA_CERT_FILE_ENV: "/path/to/not_readable"
+        }
+
+        def m_getenv_return(key, *args):
+            return etcd_env_dict[key]
+        m_getenv.side_effect = m_getenv_return
+
+        self.etcd_client = Mock(spec=EtcdClient)
+        m_etcd_client.return_value = self.etcd_client
+        self.assertRaises(DataStoreError, DatastoreClient)
+        self.assertFalse(m_etcd_client.called)
 
 
 def mock_read_2_peers(path):

--- a/calico_containers/tests/unit/datastore_test.py
+++ b/calico_containers/tests/unit/datastore_test.py
@@ -1691,19 +1691,18 @@ class TestSecureDatastoreClient(unittest.TestCase):
     @patch("pycalico.datastore.etcd.Client", autospec=True)
     @patch("pycalico.datastore.os.access", autospec=True)
     @patch("pycalico.datastore.os.path.isfile", autospec=True)
-    def test_secure_etcd_no_ca(self, m_isfile, m_access, m_etcd_client,
+    def test_secure_etcd_no_cert_key(self, m_isfile, m_access, m_etcd_client,
                                m_getenv):
-        """ Test validation for secure etcd with no CA file. """
+        """ Test validation for secure etcd with just a CA file. """
         m_isfile.return_value = True
         m_access.return_value = True
-        key_file = "/path/to/key_file"
-        cert_file = "/path/to/cert_file"
+        ca_file = "/path/to/ca_file"
         etcd_env_dict = {
             ETCD_AUTHORITY_ENV   : "127.0.1.1:2380",
             ETCD_SCHEME_ENV      : "https",
-            ETCD_KEY_FILE_ENV    : key_file,
-            ETCD_CERT_FILE_ENV   : cert_file,
-            ETCD_CA_CERT_FILE_ENV: ""
+            ETCD_KEY_FILE_ENV    : "",
+            ETCD_CERT_FILE_ENV   : "",
+            ETCD_CA_CERT_FILE_ENV: ca_file
         }
 
         def m_getenv_return(key, *args):
@@ -1715,15 +1714,15 @@ class TestSecureDatastoreClient(unittest.TestCase):
         m_etcd_client.assert_called_once_with(host="127.0.1.1",
                                               port=2380,
                                               protocol="https",
-                                              cert=(cert_file, key_file),
-                                              ca_cert=None)
+                                              cert=None,
+                                              ca_cert=ca_file)
 
     @patch("pycalico.datastore.os.getenv", autospec=True)
     @patch("pycalico.datastore.etcd.Client", autospec=True)
     @patch("pycalico.datastore.os.access", autospec=True)
     @patch("pycalico.datastore.os.path.isfile", autospec=True)
     def test_secure_etcd_ca(self, m_isfile, m_access, m_etcd_client, m_getenv):
-        """ Test validation for secure etcd with a CA file. """
+        """ Test validation for secure etcd with key, cert, and CA file. """
         m_isfile.return_value = True
         m_access.return_value = True
         key_file = "/path/to/key_file"


### PR DESCRIPTION
This change requires updates to the calico-docker and calico repos.
