### PR TITLE
Rename hostname to be host and fix use of hostname parm in API

### DIFF
--- a/calico_containers/pycalico/datastore.py
+++ b/calico_containers/pycalico/datastore.py
@@ -97,7 +97,7 @@ IP_IN_IP_ENABLED = "true"
 
 # IPAM paths
 IPAM_V_PATH = "/calico/ipam/v2/"
-IPAM_HOST_PATH = IPAM_V_PATH + "host/%(hostname)s/"
+IPAM_HOST_PATH = IPAM_V_PATH + "host/%(host)s/"
 IPAM_HOST_AFFINITY_PATH = IPAM_HOST_PATH + "ipv%(version)d/block/"
 IPAM_BLOCK_PATH = IPAM_V_PATH + "assignment/ipv%(version)d/block/"
 IPAM_HANDLE_PATH = IPAM_V_PATH + "handle/"
@@ -192,7 +192,7 @@ class DatastoreClient(object):
         # watch appropriate directory trees).
         host = get_hostname()
         for version in (4, 6):
-            path = IPAM_HOST_AFFINITY_PATH % {"hostname": host,
+            path = IPAM_HOST_AFFINITY_PATH % {"host": host,
                                               "version": version}
             try:
                 self.etcd_client.write(path, None, dir=True)

--- a/calico_containers/tests/unit/ipam_test.py
+++ b/calico_containers/tests/unit/ipam_test.py
@@ -32,7 +32,7 @@ from block_test import (_test_block_empty_v4, _test_block_empty_v6,
 network = IPNetwork("192.168.25.0/24")
 BLOCK_V4_2 = IPNetwork("10.11.45.0/26")
 BLOCK_V4_3 = IPNetwork("10.11.47.0/26")
-
+TEST_HOST = "test_host1"
 
 class TestIPAMClient(unittest.TestCase):
 
@@ -41,7 +41,7 @@ class TestIPAMClient(unittest.TestCase):
         self.m_etcd_client = Mock(spec=Client)
         self.client.etcd_client = self.m_etcd_client
 
-    @patch("pycalico.block.get_hostname", return_value="test_host1")
+    @patch("pycalico.ipam.get_hostname", return_value=TEST_HOST)
     def test_auto_assign(self, m_get_hostname):
         """
         Mainline test of auto assign.
@@ -61,8 +61,7 @@ class TestIPAMClient(unittest.TestCase):
             (ipv4s, ipv6s) = self.client.auto_assign_ips(1, 0, None, {})
             assert_list_equal([IPAddress("10.11.12.0")], ipv4s)
 
-    @patch("pycalico.block.get_hostname", return_value="test_host1")
-    def test_auto_assign_dual(self, m_get_hostname):
+    def test_auto_assign_dual(self):
         """
         Test of auto assign with both IPv4 and IPv6 requests.
         """
@@ -86,13 +85,13 @@ class TestIPAMClient(unittest.TestCase):
 
         with patch("pycalico.ipam.BlockHandleReaderWriter._get_affine_blocks",
                    m_get_affine_blocks):
-            (ipv4s, ipv6s) = self.client.auto_assign_ips(1, 2, None, {})
+            (ipv4s, ipv6s) = self.client.auto_assign_ips(1, 2, None, {},
+                                                         host=TEST_HOST)
             assert_list_equal([IPAddress("10.11.12.0")], ipv4s)
             assert_list_equal([IPAddress("2001:abcd:def0::"),
                                IPAddress("2001:abcd:def0::1")], ipv6s)
 
-    @patch("pycalico.block.get_hostname", return_value="test_host1")
-    def test_auto_assign_1st_block_full(self, m_get_hostname):
+    def test_auto_assign_1st_block_full(self):
         """
         Test auto assign when 1st block is full.
         """
@@ -101,7 +100,7 @@ class TestIPAMClient(unittest.TestCase):
             return [BLOCK_V4_1, BLOCK_V4_2]
 
         block0 = _test_block_empty_v4()
-        _ = block0.auto_assign(256, None, {}, affinity_check=False)
+        _ = block0.auto_assign(256, None, {}, TEST_HOST, affinity_check=False)
         m_result0 = Mock(spec=EtcdResult)
         m_result0.value = block0.to_json()
         block1 = _test_block_empty_v4()
@@ -113,11 +112,11 @@ class TestIPAMClient(unittest.TestCase):
 
         with patch("pycalico.ipam.BlockHandleReaderWriter._get_affine_blocks",
                    m_get_affine_blocks):
-            (ipv4s, ipv6s) = self.client.auto_assign_ips(1, 0, None, {})
+            (ipv4s, ipv6s) = self.client.auto_assign_ips(1, 0, None, {},
+                                                         host=TEST_HOST)
             assert_list_equal([IPAddress("10.11.45.0")], ipv4s)
 
-    @patch("pycalico.block.get_hostname", return_value="test_host1")
-    def test_auto_assign_span_blocks(self, m_get_hostname):
+    def test_auto_assign_span_blocks(self):
         """
         Test auto assign when 1st block has fewer than requested addresses.
         """
@@ -127,7 +126,8 @@ class TestIPAMClient(unittest.TestCase):
 
         # 1st block has 2 free addresses.
         block0 = _test_block_empty_v4()
-        _ = block0.auto_assign(BLOCK_SIZE-2, None, {}, affinity_check=False)
+        _ = block0.auto_assign(BLOCK_SIZE-2, None, {}, TEST_HOST,
+                               affinity_check=False)
         m_result0 = Mock(spec=EtcdResult)
         m_result0.value = block0.to_json()
         # 2nd block is empty.
@@ -140,14 +140,14 @@ class TestIPAMClient(unittest.TestCase):
 
         with patch("pycalico.ipam.BlockHandleReaderWriter._get_affine_blocks",
                    m_get_affine_blocks):
-            (ipv4s, ipv6s) = self.client.auto_assign_ips(4, 0, None, {})
+            (ipv4s, ipv6s) = self.client.auto_assign_ips(4, 0, None, {},
+                                                         host=TEST_HOST)
             assert_list_equal([BLOCK_V4_1[-2],
                                BLOCK_V4_1[-1],
                                BLOCK_V4_2[0],
                                BLOCK_V4_2[1]], ipv4s)
 
-    @patch("pycalico.block.get_hostname", return_value="test_host1")
-    def test_auto_assign_not_enough_addrs(self, m_get_hostname):
+    def test_auto_assign_not_enough_addrs(self):
         """
         Test auto assign when there aren't enough addresses, and no free
         blocks.
@@ -163,12 +163,14 @@ class TestIPAMClient(unittest.TestCase):
 
         # 1st block has 2 free addresses.
         block0 = _test_block_empty_v4()
-        _ = block0.auto_assign(BLOCK_SIZE-2, None, {}, affinity_check=False)
+        _ = block0.auto_assign(BLOCK_SIZE-2, None, {}, TEST_HOST,
+                               affinity_check=False)
         m_result0 = Mock(spec=EtcdResult)
         m_result0.value = block0.to_json()
         # 2nd block has 1 free address.
         block1 = _test_block_empty_v4()
-        _ = block1.auto_assign(BLOCK_SIZE-1, None, {}, affinity_check=False)
+        _ = block1.auto_assign(BLOCK_SIZE-1, None, {}, TEST_HOST,
+                               affinity_check=False)
         block1.cidr = BLOCK_V4_2
         m_result1 = Mock(spec=EtcdResult)
         m_result1.value = block1.to_json()
@@ -183,13 +185,13 @@ class TestIPAMClient(unittest.TestCase):
                    m_get_affine_blocks),\
              patch("pycalico.datastore.DatastoreClient.get_ip_pools",
                    m_get_ip_pools):
-            (ipv4s, ipv6s) = self.client.auto_assign_ips(4, 0, None, {})
+            (ipv4s, ipv6s) = self.client.auto_assign_ips(4, 0, None, {},
+                                                         host=TEST_HOST)
             assert_list_equal([BLOCK_V4_1[-2],
                                BLOCK_V4_1[-1],
                                BLOCK_V4_2[-1]], ipv4s)
 
-    @patch("pycalico.block.get_hostname", return_value="test_host1")
-    def test_auto_assign_cas_fails(self, m_get_hostname):
+    def test_auto_assign_cas_fails(self):
         """
         Test auto assign when 1st block compare-and-swap fails.
         """
@@ -199,11 +201,12 @@ class TestIPAMClient(unittest.TestCase):
 
         # 1st read, 1st block has 2 free addresses.
         block0 = _test_block_empty_v4()
-        _ = block0.auto_assign(BLOCK_SIZE-2, None, {}, affinity_check=False)
+        _ = block0.auto_assign(BLOCK_SIZE-2, None, {}, TEST_HOST,
+                               affinity_check=False)
         m_result0 = Mock(spec=EtcdResult)
         m_result0.value = block0.to_json()
         # 2nd read, 1st block has 1 free addresses.
-        _ = block0.auto_assign(1, None, {}, affinity_check=False)
+        _ = block0.auto_assign(1, None, {}, TEST_HOST, affinity_check=False)
         m_result1 = Mock(spec=EtcdResult)
         m_result1.value = block0.to_json()
         # 2nd block is empty.
@@ -220,14 +223,14 @@ class TestIPAMClient(unittest.TestCase):
 
         with patch("pycalico.ipam.BlockHandleReaderWriter._get_affine_blocks",
                    m_get_affine_blocks):
-            (ipv4s, ipv6s) = self.client.auto_assign_ips(4, 0, None, {})
+            (ipv4s, ipv6s) = self.client.auto_assign_ips(4, 0, None, {},
+                                                         host=TEST_HOST)
             assert_list_equal([BLOCK_V4_1[-1],
                                BLOCK_V4_2[0],
                                BLOCK_V4_2[1],
                                BLOCK_V4_2[2]], ipv4s)
 
-    @patch("pycalico.block.get_hostname", return_value="test_host1")
-    def test_auto_assign_with_handle_cas_failure(self, m_gethostname):
+    def test_auto_assign_with_handle_cas_failure(self):
         """
         Test of auto assign with an existing handle, and transient CAS errors.
         """
@@ -282,7 +285,8 @@ class TestIPAMClient(unittest.TestCase):
 
         with patch("pycalico.ipam.BlockHandleReaderWriter._get_affine_blocks",
                    m_get_affine_blocks):
-            (ipv4s, ipv6s) = self.client.auto_assign_ips(1, 0, handle_id, {})
+            (ipv4s, ipv6s) = self.client.auto_assign_ips(1, 0, handle_id, {},
+                                                         host=TEST_HOST)
             assert_list_equal([IPAddress("10.11.12.0")], ipv4s)
 
         # Validate the handle data stored.  We should have two reserved in the
@@ -291,8 +295,7 @@ class TestIPAMClient(unittest.TestCase):
         self.assertEqual(handle.handle_id, handle_id)
         self.assertEqual(handle.block, {"10.11.12.0/26": 2})
 
-    @patch("pycalico.block.get_hostname", return_value="test_host1")
-    def test_auto_assign_persistent_cas(self, m_get_hostname):
+    def test_auto_assign_persistent_cas(self):
         """
         Test of auto assign with persistent CAS errors.
         """
@@ -317,10 +320,9 @@ class TestIPAMClient(unittest.TestCase):
         with patch("pycalico.ipam.BlockHandleReaderWriter._get_affine_blocks",
                    m_get_affine_blocks):
             self.assertRaises(RuntimeError, self.client.auto_assign_ips,
-                              1, 0, None, {})
+                              1, 0, None, {}, host=TEST_HOST)
 
-    @patch("pycalico.block.get_hostname", return_value="test_host1")
-    def test_auto_assign_no_blocks(self, m_get_hostname):
+    def test_auto_assign_no_blocks(self):
         """
         Test auto assign when we haven't allocated blocks yet, but there are
         free blocks available.
@@ -351,15 +353,15 @@ class TestIPAMClient(unittest.TestCase):
                    m_get_affine_blocks),\
              patch("pycalico.datastore.DatastoreClient.get_ip_pools",
                    m_get_ip_pools):
-            (ipv4s, ipv6s) = self.client.auto_assign_ips(4, 0, None, {})
+            (ipv4s, ipv6s) = self.client.auto_assign_ips(4, 0, None, {},
+                                                         host=TEST_HOST)
             assert_equal(self.m_etcd_client.read.call_count, 2)
             assert_list_equal([IPAddress("192.168.0.0"),
                                IPAddress("192.168.0.1"),
                                IPAddress("192.168.0.2"),
                                IPAddress("192.168.0.3")], ipv4s)
 
-    @patch("pycalico.block.get_hostname", return_value="test_host1")
-    def test_auto_assign_random_blocks(self, m_get_hostname):
+    def test_auto_assign_random_blocks(self):
         """
         Test auto assign when all blocks our blocks are full and all other
         blocks already have host affinity.
@@ -377,7 +379,7 @@ class TestIPAMClient(unittest.TestCase):
             if block_cidr in affine_blocks:
                 # All our blocks are full.
                 block = AllocationBlock(block_cidr, "test_host1")
-                block.auto_assign(256, None, {})
+                block.auto_assign(256, None, {}, TEST_HOST)
             else:
                 # Other blocks are not.
                 block = AllocationBlock(block_cidr, "test_host2")
@@ -394,15 +396,15 @@ class TestIPAMClient(unittest.TestCase):
                    m_get_ip_pools),\
              patch("pycalico.ipam.BlockHandleReaderWriter._read_block",
                    m_read_block):
-            (ipv4s, ipv6s) = self.client.auto_assign_ips(4, 0, None, {})
+            (ipv4s, ipv6s) = self.client.auto_assign_ips(4, 0, None, {},
+                                                         host=TEST_HOST)
             assert_equal(len(ipv4s), 4)
             assert_equal(len(rando_blocks), 1)
             rando_block = rando_blocks.pop()
             for ip in ipv4s:
                 assert_true(ip in rando_block.cidr)
 
-    @patch("pycalico.block.get_hostname", return_value="test_host1")
-    def test_auto_assign_bad_affinity(self, m_get_hostname):
+    def test_auto_assign_bad_affinity(self):
         """
         Test auto assign when _get_affine_blocks returns some blocks that
         don't exist or don't actually have host affinity.
@@ -478,13 +480,13 @@ class TestIPAMClient(unittest.TestCase):
                    m_get_ip_pools),\
              patch("pycalico.ipam.BlockHandleReaderWriter._read_block",
                    m_read_block):
-            (ipv4s, ipv6s) = self.client.auto_assign_ips(4, 0, None, {})
+            (ipv4s, ipv6s) = self.client.auto_assign_ips(4, 0, None, {},
+                                                         host=TEST_HOST)
             assert_equal(len(ipv4s), 4)
             for ip in ipv4s:
                 assert_true(ip in BLOCK_V4_3)
 
-    @patch("pycalico.block.get_hostname", return_value="test_host1")
-    def test_auto_assign_affinity_key_err_retries(self, m_get_hostname):
+    def test_auto_assign_affinity_key_err_retries(self):
         """
         Test auto assign when _get_affine_blocks returns some blocks that
         don't exist and we hit the maximum number of retries.
@@ -518,7 +520,8 @@ class TestIPAMClient(unittest.TestCase):
                    m_get_ip_pools),\
              patch("pycalico.ipam.BlockHandleReaderWriter._read_block",
                    m_read_block):
-            (ipv4s, ipv6s) = self.client.auto_assign_ips(4, 0, None, {})
+            (ipv4s, ipv6s) = self.client.auto_assign_ips(4, 0, None, {},
+                                                         host=TEST_HOST)
             assert_equal(len(ipv4s), 4)
             for ip in ipv4s:
                 assert_true(ip in first_free_block)
@@ -530,8 +533,7 @@ class TestIPAMClient(unittest.TestCase):
                 call(first_free_block)
             ])
 
-    @patch("pycalico.block.get_hostname", return_value="test_host1")
-    def test_assign(self, m_get_hostname):
+    def test_assign(self):
         """
         Mainline test of assign_ip().
         """
@@ -542,15 +544,14 @@ class TestIPAMClient(unittest.TestCase):
         self.m_etcd_client.read.return_value = m_result
 
         ip0 = IPAddress("10.11.12.55")
-        self.client.assign_ip(ip0, None, {})
+        self.client.assign_ip(ip0, None, {}, host=TEST_HOST)
         self.m_etcd_client.update.assert_called_once_with(m_result)
 
         # Assert the JSON shows the address allocated.
         json_dict = json.loads(m_result.value)
         assert_equal(json_dict[AllocationBlock.ALLOCATIONS][55], 0)
 
-    @patch("pycalico.block.get_hostname", return_value="test_host1")
-    def test_assign_cas_fails(self, m_get_hostname):
+    def test_assign_cas_fails(self):
         """
         Test assign_ip() when the compare-and-swap fails.
         """
@@ -567,7 +568,7 @@ class TestIPAMClient(unittest.TestCase):
                                                  None]
 
         ip0 = IPAddress("10.11.12.55")
-        self.client.assign_ip(ip0, None, {})
+        self.client.assign_ip(ip0, None, {}, host=TEST_HOST)
         self.m_etcd_client.update.assert_has_calls([call(m_result0),
                                                     call(m_result1)])
 
@@ -575,8 +576,7 @@ class TestIPAMClient(unittest.TestCase):
         json_dict = json.loads(m_result1.value)
         assert_equal(json_dict[AllocationBlock.ALLOCATIONS][55], 0)
 
-    @patch("pycalico.block.get_hostname", return_value="test_host1")
-    def test_assign_with_handle_cas_fails(self, m_get_hostname):
+    def test_assign_with_handle_cas_fails(self):
         """
         Test assign_ip() using a handle when the compare-and-swap fails.
         """
@@ -626,7 +626,7 @@ class TestIPAMClient(unittest.TestCase):
         self.m_etcd_client.update.side_effect = update
 
         ip0 = IPAddress("10.11.12.55")
-        self.client.assign_ip(ip0, handle_id, {})
+        self.client.assign_ip(ip0, handle_id, {}, host=TEST_HOST)
 
         # Assert the Block JSON shows the address allocated, and the handle
         # JSON shows the assignment.
@@ -640,8 +640,7 @@ class TestIPAMClient(unittest.TestCase):
         self.assertDictEqual(handle.block, {"10.11.12.0/26": 1,
                                             "10.11.13.0/26": 5})
 
-    @patch("pycalico.block.get_hostname", return_value="test_host1")
-    def test_assign_persistent_cas_fails(self, m_get_hostname):
+    def test_assign_persistent_cas_fails(self):
         """
         Test assign_ip() when the compare-and-swap fails persistently.
         """
@@ -658,10 +657,10 @@ class TestIPAMClient(unittest.TestCase):
         self.m_etcd_client.update.side_effect = EtcdCompareFailed()
 
         ip0 = IPAddress("10.11.12.55")
-        self.assertRaises(RuntimeError, self.client.assign_ip, ip0, None, {})
+        self.assertRaises(RuntimeError, self.client.assign_ip, ip0, None, {},
+                          host=TEST_HOST)
 
-    @patch("pycalico.block.get_hostname", return_value="test_host1")
-    def test_assign_new_block(self, m_get_hostname):
+    def test_assign_new_block(self):
         """
         Test assign_ip() when address is in a block that hasn't been written.
         """
@@ -679,7 +678,7 @@ class TestIPAMClient(unittest.TestCase):
         with patch("pycalico.datastore.DatastoreClient.get_ip_pools",
                    m_get_ip_pools):
             ip0 = IPAddress("10.11.12.55")
-            self.client.assign_ip(ip0, None, {})
+            self.client.assign_ip(ip0, None, {}, host=TEST_HOST)
 
         # Verify we wrote a new block
         # Two calls to write() -- one for recording affinity, the other the
@@ -694,7 +693,7 @@ class TestIPAMClient(unittest.TestCase):
         assert_equal(json_dict[AllocationBlock.ALLOCATIONS][55], 0)
         assert_dict_equal({"prevExist": False}, kwargs)
 
-    @patch("pycalico.block.get_hostname", return_value="test_host1")
+    @patch("pycalico.ipam.get_hostname", return_value="DifferentHost")
     def test_assign_new_block_cas_error(self, m_get_hostname):
         """
         Test assign_ip() when address is in a new block.
@@ -739,8 +738,7 @@ class TestIPAMClient(unittest.TestCase):
         json_dict = json.loads(m_result1.value)
         assert_equal(json_dict[AllocationBlock.ALLOCATIONS][55], 0)
 
-    @patch("pycalico.block.get_hostname", return_value="test_host1")
-    def test_assign_not_in_pools(self, m_get_hostname):
+    def test_assign_not_in_pools(self):
         """
         Test assign_ip() when address is not in configured pools.
         """
@@ -755,69 +753,12 @@ class TestIPAMClient(unittest.TestCase):
         with patch("pycalico.datastore.DatastoreClient.get_ip_pools",
                    m_get_ip_pools):
             ip0 = IPAddress("10.12.12.55")
-            assert_raises(ValueError, self.client.assign_ip, ip0, None, {})
+            assert_raises(ValueError, self.client.assign_ip, ip0, None, {},
+                          host=TEST_HOST)
 
         # Verify we did not write anything.
         assert_false(self.m_etcd_client.write.called)
         assert_false(self.m_etcd_client.update.called)
-
-    def test_assign_address(self):
-        """
-        Mainline test of assign_address().
-        """
-
-        block = _test_block_empty_v4()
-        m_result = Mock(spec=EtcdResult)
-        m_result.value = block.to_json()
-        self.m_etcd_client.read.return_value = m_result
-
-        ip0 = IPAddress("10.11.12.55")
-        pool = IPPool("10.11.0.0/16")
-        success = self.client.assign_address(pool, ip0)
-        assert_true(success)
-        self.m_etcd_client.update.assert_called_once_with(m_result)
-
-        # Assert the JSON shows the address allocated.
-        json_dict = json.loads(m_result.value)
-        assert_equal(json_dict[AllocationBlock.ALLOCATIONS][55], 0)
-
-    def test_assign_address_no_pool(self):
-        """
-        Test assign_address when there are no IPPools in the data store.
-        """
-
-        self.m_etcd_client.read.side_effect = EtcdKeyNotFound
-
-        ip0 = IPAddress("10.11.12.55")
-        self.assertRaises(PoolNotFound, self.client.assign_address, None, ip0)
-
-    def test_assign_address_fails(self):
-        """
-        Test assign_address() when it fails.
-        """
-        ip0 = IPAddress("10.11.12.55")
-
-        block = _test_block_empty_v4()
-        block.assign(ip0, None, {})
-        m_result = Mock(spec=EtcdResult)
-        m_result.value = block.to_json()
-        self.m_etcd_client.read.return_value = m_result
-
-        pool = IPPool("10.11.0.0/16")
-        success = self.client.assign_address(pool, ip0)
-        assert_false(success)
-        assert_false(self.m_etcd_client.update.called)
-
-    def test_unassign_address_no_pool(self):
-        """
-        Test unassign_address() where there are no IPPools in the data store.
-        """
-
-        self.m_etcd_client.read.side_effect = EtcdKeyNotFound
-
-        ip0 = IPAddress("10.11.12.55")
-        self.assertRaises(PoolNotFound, self.client.unassign_address,
-                          None, ip0)
 
     def test_release_basic(self):
         """
@@ -1170,51 +1111,6 @@ class TestIPAMClient(unittest.TestCase):
 
         self.client.release_ip_by_handle(handle_id)
         self.assertEqual(self.m_etcd_client.update.call_count, 0)
-
-    def test_unassign_address(self):
-        """
-        Basic test of unassign_address
-        """
-        ip4 = BLOCK_V4_1[13]
-        m_result4 = Mock(spec=EtcdResult)
-
-        def m_read_block(_self, block_cidr):
-            block4 = _test_block_empty_v4()
-            block4.assign(ip4, None, {})
-            block4.db_result = m_result4
-            if block_cidr == block4.cidr:
-                return block4
-            assert_true(False, "Unexpected block CIDR")
-
-        with patch("pycalico.ipam.BlockHandleReaderWriter._read_block",
-                   m_read_block):
-            pool = IPPool("10.11.0.0/16")
-            success = self.client.unassign_address(pool, ip4)
-            assert_true(success)
-
-        self.m_etcd_client.update.assert_called_once_with(m_result4)
-
-    def test_unassign_address_fails(self):
-        """
-        Test of unassign_address when it fails
-        """
-        ip4 = BLOCK_V4_1[13]
-        m_result4 = Mock(spec=EtcdResult)
-
-        def m_read_block(_self, block_cidr):
-            block4 = _test_block_empty_v4()
-            block4.db_result = m_result4
-            if block_cidr == block4.cidr:
-                return block4
-            assert_true(False, "Unexpected block CIDR")
-
-        with patch("pycalico.ipam.BlockHandleReaderWriter._read_block",
-                   m_read_block):
-            pool = IPPool("10.11.0.0/16")
-            success = self.client.unassign_address(pool, ip4)
-            assert_false(success)
-
-        assert_false(self.m_etcd_client.update.called)
 
     def test_get_ip_assignments_by_handle(self):
         """


### PR DESCRIPTION
Allow host to be passed in on assign ip methods.
