### PR TITLE
Release by handle should update the unallocated array

### DIFF
--- a/calico_containers/pycalico/block.py
+++ b/calico_containers/pycalico/block.py
@@ -337,6 +337,7 @@ class AllocationBlock(object):
             # Release the addresses.
             for ordinal in ordinals:
                 self.allocations[ordinal] = None
+                self.unallocated.append(ordinal)
             return len(ordinals)
         else:
             # Nothing to release.

--- a/calico_containers/tests/unit/block_test.py
+++ b/calico_containers/tests/unit/block_test.py
@@ -621,6 +621,20 @@ class TestAllocationBlock(unittest.TestCase):
         assert_raises(AddressNotAssignedError,
                       block0.get_attributes_for_ip, ip1)
 
+    def test_release_by_handle(self):
+        """
+        Mainline test for release_by_handle()
+        """
+        block = _test_block_not_empty_v4()
+        block.release_by_handle("key1")
+
+        # Check allocations indicate the IPs are now released.
+        assert_is_none(block.allocations[2])
+        assert_is_none(block.allocations[4])
+
+        # Check that the unallocated list has the released ordinals appended.
+        assert_list_equal(block.unallocated[-2:], [2, 4])
+
 
 class TestGetBlockCIDRForAddress(unittest.TestCase):
 

--- a/calico_containers/tests/unit/ipam_test.py
+++ b/calico_containers/tests/unit/ipam_test.py
@@ -1049,6 +1049,15 @@ class TestIPAMClient(unittest.TestCase):
         self.m_etcd_client.delete.assert_called_once_with(m_resulth.key,
                                                           prevIndex=55555)
 
+        # Check the updated results, the IPs should not be allocated, and added
+        # to the end of the unallocated list.
+        block4 = AllocationBlock.from_etcd_result(m_resultb4)
+        block6 = AllocationBlock.from_etcd_result(m_resultb6)
+        self.assertIsNone(block4.allocations[13])
+        self.assertIsNone(block6.allocations[45])
+        self.assertEquals(block4.unallocated[-1], 13)
+        self.assertEquals(block6.unallocated[-1], 45)
+
     def test_release_ip_by_handle_no_block(self):
         """
         Test of release_ip_by_handle when referenced block does not exist.


### PR DESCRIPTION
Spike - spotted this while doing the IPAM stuff - I wasn't setting the unallocated entry in the release by handle method.
