### PR TITLE
Build calico/build from local libcalico code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,3 +25,5 @@ RUN apt-get update && \
 ADD build-requirements.txt /code/
 RUN pip install setuptools==0.7.7
 RUN pip install -r build-requirements.txt
+ADD . /code
+RUN pip install -e /code

--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -5,5 +5,4 @@ docker-py==1.2.1
 sh==1.11
 prettytable==0.7.2
 netaddr==0.7.15
-git+https://github.com/projectcalico/libcalico.git
 ConcurrentLogHandler


### PR DESCRIPTION
Docker hub is set up so that when we tag a release we'll automatically get a tagged docker image
