### PR TITLE
Raise error if IPPool is created with a bad cidr block size

### DIFF
--- a/calico_containers/pycalico/block.py
+++ b/calico_containers/pycalico/block.py
@@ -544,8 +544,8 @@ class AddressNotAssignedError(BlockError):
     """
     pass
 
-class AddressRangeNotAllowedError(BlockError):
+class CidrTooSmallError(BlockError):
     """
-    Tried to assign an address range that does not fit a block size.
+    Tried to assign a CIDR that is too small to fit in an IP block.
     """
     pass

--- a/calico_containers/pycalico/block.py
+++ b/calico_containers/pycalico/block.py
@@ -543,3 +543,9 @@ class AddressNotAssignedError(BlockError):
     Tried to query an address that isn't assigned.
     """
     pass
+
+class AddressRangeNotAllowedError(BlockError):
+    """
+    Tried to assign an address range that does not fit a block size.
+    """
+    pass

--- a/calico_containers/pycalico/datastore_datatypes.py
+++ b/calico_containers/pycalico/datastore_datatypes.py
@@ -24,7 +24,7 @@ from netaddr import IPAddress, IPNetwork
 
 from pycalico.util import generate_cali_interface_name, validate_characters, \
     validate_ports, validate_icmp_type
-from pycalico.block import AddressRangeNotAllowedError, BLOCK_PREFIXLEN
+from pycalico.block import CidrTooSmallError, BLOCK_PREFIXLEN
 
 
 IF_PREFIX = "cali"
@@ -140,11 +140,12 @@ class IPPool(object):
         self.ipam = bool(ipam)
         if self.ipam:
             if self.cidr.prefixlen > BLOCK_PREFIXLEN[self.cidr.version]:
-                raise AddressRangeNotAllowedError("The cidr block size for an "
-                    "ipv%s IPPool must have a prefix length of %s or lower. "
-                    "Given: %s" % (self.cidr.version,
-                                   BLOCK_PREFIXLEN[self.cidr.version],
-                                   self.cidr.prefixlen))
+                raise CidrTooSmallError("The CIDR block size for an "
+                    "IPv%s pool when using Calico IPAM must have a prefix "
+                    "length of %s or lower. Given: %s" %
+                    (self.cidr.version,
+                     BLOCK_PREFIXLEN[self.cidr.version],
+                     self.cidr.prefixlen))
         self.ipip = bool(ipip)
         self.masquerade = bool(masquerade)
 

--- a/calico_containers/tests/unit/datastore_test.py
+++ b/calico_containers/tests/unit/datastore_test.py
@@ -32,6 +32,7 @@ from pycalico.datastore_errors import DataStoreError, ProfileNotInEndpoint, Prof
     MultipleEndpointsMatch
 from pycalico.datastore_datatypes import Rules, BGPPeer, IPPool, \
     Endpoint, Profile, Rule
+from pycalico.block import AddressRangeNotAllowedError
 
 TEST_HOST = "TEST_HOST"
 TEST_ORCH_ID = "docker"
@@ -489,6 +490,28 @@ class TestIPPool(unittest.TestCase):
         """
         assert_equal("1.2.3.0/24",
                       str(IPPool("1.2.3.4/24", ipip=True, masquerade=True)))
+
+    def test_init(self):
+        """
+        Test __init__ allows correct IPPools
+        """
+        bad_cidr1 = "10.10.10.10/32"
+        bad_cidr2 = "172.25.20.0/30"
+        bad_cidr3 = "ffff::/128"
+        good_cidr1 = "10.10.10.10/24"
+        good_cidr2 = "ffff::/120"
+        self.assertRaises(AddressRangeNotAllowedError,
+                          IPPool, bad_cidr1, ipam=True)
+        self.assertRaises(AddressRangeNotAllowedError,
+                          IPPool, bad_cidr2, ipam=True)
+        self.assertRaises(AddressRangeNotAllowedError,
+                          IPPool, bad_cidr3, ipam=True)
+        try:
+            IPPool(good_cidr1, ipam=True)
+            IPPool(good_cidr2, ipam=True)
+            IPPool(bad_cidr1, ipam=False)
+        except AddressRangeNotAllowedError:
+            self.fail("Received unexpected AddressRangeNotAllowedError")
 
 
 class TestDatastoreClient(unittest.TestCase):

--- a/calico_containers/tests/unit/datastore_test.py
+++ b/calico_containers/tests/unit/datastore_test.py
@@ -32,7 +32,7 @@ from pycalico.datastore_errors import DataStoreError, ProfileNotInEndpoint, Prof
     MultipleEndpointsMatch
 from pycalico.datastore_datatypes import Rules, BGPPeer, IPPool, \
     Endpoint, Profile, Rule
-from pycalico.block import AddressRangeNotAllowedError
+from pycalico.block import CidrTooSmallError
 
 TEST_HOST = "TEST_HOST"
 TEST_ORCH_ID = "docker"
@@ -500,17 +500,17 @@ class TestIPPool(unittest.TestCase):
         bad_cidr3 = "ffff::/128"
         good_cidr1 = "10.10.10.10/24"
         good_cidr2 = "ffff::/120"
-        self.assertRaises(AddressRangeNotAllowedError,
+        self.assertRaises(CidrTooSmallError,
                           IPPool, bad_cidr1, ipam=True)
-        self.assertRaises(AddressRangeNotAllowedError,
+        self.assertRaises(CidrTooSmallError,
                           IPPool, bad_cidr2, ipam=True)
-        self.assertRaises(AddressRangeNotAllowedError,
+        self.assertRaises(CidrTooSmallError,
                           IPPool, bad_cidr3, ipam=True)
         try:
             IPPool(good_cidr1, ipam=True)
             IPPool(good_cidr2, ipam=True)
             IPPool(bad_cidr1, ipam=False)
-        except AddressRangeNotAllowedError:
+        except CidrTooSmallError:
             self.fail("Received unexpected AddressRangeNotAllowedError")
 
 


### PR DESCRIPTION
Fixes https://github.com/projectcalico/calico-containers/issues/505
