### PR TITLE
Randomise selection order for affine blocks.

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,3 @@
+The _random_subnets_from_cidr() function in calico_containers/pycalico/ipam.py
+is derived from code in the netaddr library, which is distributed under the
+3-clause BSD license, see copyright and notices in licenses/netaddr.

--- a/licenses/netaddr
+++ b/licenses/netaddr
@@ -1,0 +1,37 @@
+
+Here are the licenses applicable to the use of the netaddr library.
+
+-------
+netaddr
+-------
+
+COPYRIGHT AND LICENSE
+
+Copyright (c) 2008-2015, David P. D. Moss. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+* Neither the name of David P. D. Moss nor the names of contributors
+  may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
I think this is what's needed to avoid contention when many hosts assign IPAM blocks concurrently.  I'm just about to try it in a scale test, though...
