### PR TITLE
Disable felix status reporting by default.

### DIFF
--- a/calico_containers/pycalico/datastore.py
+++ b/calico_containers/pycalico/datastore.py
@@ -89,6 +89,7 @@ IP_IN_IP_PATH = CONFIG_PATH + "IpInIpEnabled"
 LOG_SEVERITY_FILE_PATH = CONFIG_PATH + "LogSeverityFile"
 LOG_SEVERITY_SCREEN_PATH = CONFIG_PATH + "LogSeverityScreen"
 LOG_FILE_PATH_PATH = CONFIG_PATH + "LogFilePath"
+FELIX_REPORTING_INTERVAL_PATH = CONFIG_PATH + "ReportingIntervalSecs"
 
 # The default node AS number.
 DEFAULT_AS_NUM = 64511
@@ -284,8 +285,11 @@ class DatastoreClient(object):
         self._write_global_config(LOG_FILE_PATH_PATH,
                                   DEFAULT_LOG_FILE_PATH)
 
-        # IP in IP is enabled globally.
+        # IP in IP is disabled globally.
         self._write_global_config(IP_IN_IP_PATH, IP_IN_IP_DISABLED)
+
+        # Disable felix status reporting, which consumes etcd write bandwidth.
+        self._write_global_config(FELIX_REPORTING_INTERVAL_PATH, "0")
 
         # We are always ready.
         self.etcd_client.write(CALICO_V_PATH + "/Ready", "true")

--- a/calico_containers/tests/unit/test_datastore.py
+++ b/calico_containers/tests/unit/test_datastore.py
@@ -543,6 +543,7 @@ class TestDatastoreClient(unittest.TestCase):
         log_screen_path = CONFIG_PATH + "LogSeverityScreen"
         log_file_path_path = CONFIG_PATH + "LogFilePath"
         ipip_path = CONFIG_PATH + "IpInIpEnabled"
+        reporting_int_path = CONFIG_PATH + "ReportingIntervalSecs"
         self.etcd_client.read.side_effect = EtcdKeyNotFound
 
         # We only write the interface prefix if there is no entry in the
@@ -557,7 +558,8 @@ class TestDatastoreClient(unittest.TestCase):
                           call(log_file_path),
                           call(log_screen_path),
                           call(log_file_path_path),
-                          call(ipip_path)]
+                          call(ipip_path),
+                          call(reporting_int_path)]
         self.etcd_client.read.assert_has_calls(expected_reads)
 
         expected_writes = [call(int_prefix_path, "cali"),
@@ -571,6 +573,7 @@ class TestDatastoreClient(unittest.TestCase):
                            call(log_screen_path, "info"),
                            call(log_file_path_path, "none"),
                            call(ipip_path, "false"),
+                           call(reporting_int_path, "0"),
                            call(CALICO_V_PATH + "/Ready", "true")]
         self.etcd_client.write.assert_has_calls(expected_writes)
 
@@ -593,6 +596,7 @@ class TestDatastoreClient(unittest.TestCase):
         log_screen_path = CONFIG_PATH + "LogSeverityScreen"
         log_file_path_path = CONFIG_PATH + "LogFilePath"
         ipip_path = CONFIG_PATH + "IpInIpEnabled"
+        reporting_int_path = CONFIG_PATH + "ReportingIntervalSecs"
         self.etcd_client.read.side_effect = EtcdKeyNotFound
 
         self.datastore.ensure_global_config()
@@ -608,6 +612,7 @@ class TestDatastoreClient(unittest.TestCase):
                            call(log_screen_path, "info"),
                            call(log_file_path_path, "none"),
                            call(ipip_path, "false"),
+                           call(reporting_int_path, "0"),
                            call(CALICO_V_PATH + "/Ready", "true")]
         self.etcd_client.write.assert_has_calls(expected_writes)
 


### PR DESCRIPTION
Fixes https://github.com/projectcalico/calico-containers/issues/970

Felix supports reporting its status into etcd, which we use in the OpenStack integration to report the agent status. That feature is currently turned on in the container integration even though we're not exposing it anywhere.

At high scale, it uses a significant chunk of etcd write bandwidth (the default is to write 2 etcd keys every 30s from every felix).

We should turn this off until it's needed.
