### PR TITLE
Add python files as a Makefile dependency for the build image.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ update-frozen:
 	docker build -t calico/build .
 	docker run --rm calico/build pip freeze | grep -v pycalico > build-requirements-frozen.txt
 
-calicobuild.created: $(BUILD_FILES)
+calicobuild.created: $(BUILD_FILES) $(PYCALICO)
 	docker build -t calico/build .
 	touch calicobuild.created
 


### PR DESCRIPTION
Ensures changes to python files trigger rebuild of the image.
