### PR TITLE
Add and test new validate_port_spec utility

### DIFF
--- a/calico_containers/pycalico/util.py
+++ b/calico_containers/pycalico/util.py
@@ -104,6 +104,13 @@ def get_hostname():
         return socket.gethostname()
 
 
+def validate_port_str(port_str):
+    """
+    Checks whether the command line word specifying a set of ports is valid.
+    """
+    return validate_ports(port_str.split(","))
+
+
 def validate_ports(port_list):
     """
     Checks whether a list of ports are within range of 0 and 65535.

--- a/calico_containers/tests/unit/test_util.py
+++ b/calico_containers/tests/unit/test_util.py
@@ -17,7 +17,7 @@ from mock import patch
 from netaddr import IPAddress
 from subprocess import CalledProcessError, check_output
 from pycalico.util import get_host_ips, validate_characters, validate_ports, validate_icmp_type, validate_hostname_port, \
-    validate_cidr_versions, validate_ip, validate_cidr
+    validate_cidr_versions, validate_ip, validate_cidr, validate_port_str
 from nose_parameterized import parameterized
 
 MOCK_IP_ADDR = \
@@ -200,6 +200,25 @@ class TestUtil(unittest.TestCase):
         Test validate_ports function
         """
         test_result = validate_ports(input_list)
+        self.assertEqual(expected_result, test_result)
+
+    # Each input parameter for this test is the command line word following 'to
+    # ports' or 'from ports'.
+    @parameterized.expand([
+        ('2,5,114', True),
+        ('89:133,19', True),
+        ('15,66,-144', False),
+        ('-1:5', False),
+        ('15:77:66', False),
+        ('39040:39080', True),
+        ('39080:39040', False),
+        ('one,two', False)
+    ])
+    def test_validate_port_str(self, input_word, expected_result):
+        """
+        Test validate_port_str function
+        """
+        test_result = validate_port_str(input_word)
         self.assertEqual(expected_result, test_result)
 
     @parameterized.expand([

--- a/calico_containers/tests/unit/test_util.py
+++ b/calico_containers/tests/unit/test_util.py
@@ -22,27 +22,27 @@ from nose_parameterized import parameterized
 
 MOCK_IP_ADDR = \
 """
-1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default 
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default
     link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
     inet 127.0.0.1/8 scope host lo
        valid_lft forever preferred_lft forever
-    inet6 ::1/128 scope host 
+    inet6 ::1/128 scope host
        valid_lft forever preferred_lft forever
 2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
     link/ether 08:00:27:73:c8:d0 brd ff:ff:ff:ff:ff:ff
     inet 172.24.114.18/24 brd 172.24.114.255 scope global eth0
        valid_lft forever preferred_lft forever
-    inet6 2620:104:4008:69:8d7c:499f:2f04:9e55/64 scope global temporary dynamic 
+    inet6 2620:104:4008:69:8d7c:499f:2f04:9e55/64 scope global temporary dynamic
        valid_lft 603690sec preferred_lft 84690sec
-    inet6 2620:104:4008:69:a00:27ff:fe73:c8d0/64 scope global dynamic 
+    inet6 2620:104:4008:69:a00:27ff:fe73:c8d0/64 scope global dynamic
        valid_lft 604698sec preferred_lft 86298sec
-    inet6 fe80::a00:27ff:fe73:c8d0/64 scope link 
+    inet6 fe80::a00:27ff:fe73:c8d0/64 scope link
        valid_lft forever preferred_lft forever
-3: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default 
+3: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default
     link/ether 00:00:00:00:00:00 brd ff:ff:ff:ff:ff:ff
     inet 172.17.42.1/24 scope global docker0
        valid_lft forever preferred_lft forever
-    inet6 fe80::188f:d6ff:fe1f:1482/64 scope link 
+    inet6 fe80::188f:d6ff:fe1f:1482/64 scope link
        valid_lft forever preferred_lft forever
 """
 
@@ -74,8 +74,8 @@ MOCK_IP_ADDR_DOCKER_NONE = \
 
 MOCK_IP_ADDR_LOOPBACK = \
 """
-1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 
-    inet6 ::1/128 scope host 
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536
+    inet6 ::1/128 scope host
        valid_lft forever preferred_lft forever
     inet 127.0.0.1/8 scope host lo
        valid_lft forever preferred_lft forever


### PR DESCRIPTION
validate_port_spec validates the port specifications that can be
specified on the calicoctl command line.  This is different from
validate_ports, which validates the port values that can occur in the
etcd data model.
