### PR TITLE
Add function get_ipv6_link_local

### DIFF
--- a/calico_containers/pycalico/netns.py
+++ b/calico_containers/pycalico/netns.py
@@ -24,7 +24,7 @@ from copy import copy
 from subprocess32 import check_output, check_call, CalledProcessError, STDOUT
 from netaddr import IPAddress
 
-from pycalico.util import IPV6_RE
+from util import get_ipv6_link_local
 
 _log = logging.getLogger(__name__)
 _log.addHandler(logging.NullHandler())
@@ -207,13 +207,7 @@ def add_ns_default_route(namespace, veth_name_host, veth_name_ns):
     """
     # Attempt to fetch the IPv6 address for the host veth. Failure indicates
     # that this host doesn't support IPv6.
-    next_hop_6 = None
-    try:
-        ip_addr_output = check_output(["ip", "-6", "addr", "show", "dev", veth_name_host])
-        next_hop_6 = re.search(IPV6_RE, ip_addr_output).group(1)
-    except (CalledProcessError, OSError, AttributeError) as e:
-        _log.debug("Failed to get IPv6 address for veth %s. Error: %s",
-                   veth_name_host, e)
+    next_hop_6 = get_ipv6_link_local(veth_name_host)
 
     with NamedNamespace(namespace) as ns:
         # IPv4

--- a/calico_containers/pycalico/util.py
+++ b/calico_containers/pycalico/util.py
@@ -682,23 +682,21 @@ def get_ipv6_link_local(interface_name):
     Runs IP routing commands to extract the currently assigned IPv6 link-local
     address for an interface in this namespace.
 
-    :param interface_name: Name fo the target interface.
+    :param interface_name: Name of the target interface.
     :return: A string represention of the link local address, or None (if one isn't assigned).
     Will throw exception if not interface information exists for that name.
     """
-    # Find which link local was assigned to the ipv6 interface
+    # Get networking info for interface_name
     try:
         ip_addr_output = check_output(["ip", "-6", "addr", "show", "dev", interface_name])
-    except (CalledProcessError, OSError, AttributeError) as e:
-        _log.debug("Failed to get IPv6 address for veth: %s. Error: %s",
+    except CalledProcessError as e:
+        _log.debug("Failed to get IPv6 address for veth %s. Error: %s",
                 interface_name, e)
-    _log.debug("Searching for linklocal of %s in: %s", interface_name, ip_addr_output)
-
-    try:
-        next_hop_6 = re.search(IPV6_RE, ip_addr_output).group(1)
-    except AttributeError:
-        _log.warning("No nexthop found for interface %s", interface_name)
         return None
-
-    _log.info("Got nexthop %s for interface %s", next_hop_6, interface_name)
-    return next_hop_6
+    else:
+        # Search output for the assigned ipv6 addr
+        try:
+            return re.search(IPV6_RE, ip_addr_output).group(1)
+        except AttributeError:
+            _log.warning("No nexthop found for interface %s", interface_name)
+            return None

--- a/calico_containers/pycalico/util.py
+++ b/calico_containers/pycalico/util.py
@@ -676,3 +676,29 @@ def verify_ports(port_list):
                 raise RangeValidationError("Port is invalid. Value must be "
                                            "from 0 to 65535 ('{0}' given)."
                                            "".format(port))
+
+def get_ipv6_link_local(interface_name):
+    """
+    Runs IP routing commands to extract the currently assigned IPv6 link-local
+    address for an interface in this namespace.
+
+    :param interface_name: Name fo the target interface.
+    :return: A string represention of the link local address, or None (if one isn't assigned).
+    Will throw exception if not interface information exists for that name.
+    """
+    # Find which link local was assigned to the ipv6 interface
+    try:
+        ip_addr_output = check_output(["ip", "-6", "addr", "show", "dev", interface_name])
+    except (CalledProcessError, OSError, AttributeError) as e:
+        _log.debug("Failed to get IPv6 address for veth: %s. Error: %s",
+                interface_name, e)
+    _log.debug("Searching for linklocal of %s in: %s", interface_name, ip_addr_output)
+
+    try:
+        next_hop_6 = re.search(IPV6_RE, ip_addr_output).group(1)
+    except AttributeError:
+        _log.warning("No nexthop found for interface %s", interface_name)
+        return None
+
+    _log.info("Got nexthop %s for interface %s", next_hop_6, interface_name)
+    return next_hop_6

--- a/calico_containers/tests/unit/test_util.py
+++ b/calico_containers/tests/unit/test_util.py
@@ -620,3 +620,13 @@ class TestUtil(unittest.TestCase):
                 util.verify_ports(input_list)
         else:
             self.assertIsNone(util.verify_ports(input_list))
+    @patch("pycalico.util.check_output", autospec=True)
+    def test_get_ipv6_link_local(self, m_check_output):
+        output = """3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qlen 1000
+                        inet6 fd80:24e2:f998:72d7::2/112 scope global
+                            valid_lft forever preferred_lft forever
+                        inet6 fe80::a00:27ff:fe71:610f/64 scope link
+                            valid_lft forever preferred_lft forever"""
+        m_check_output.return_value = output
+        self.assertEqual(util.get_ipv6_link_local("eth1"), "fd80:24e2:f998:72d7::2")
+        m_check_output.assert_called_with(["ip", "-6", "addr", "show", "dev", "eth1"])

--- a/calico_containers/tests/unit/test_util.py
+++ b/calico_containers/tests/unit/test_util.py
@@ -620,6 +620,7 @@ class TestUtil(unittest.TestCase):
                 util.verify_ports(input_list)
         else:
             self.assertIsNone(util.verify_ports(input_list))
+
     @patch("pycalico.util.check_output", autospec=True)
     def test_get_ipv6_link_local(self, m_check_output):
         output = """3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qlen 1000


### PR DESCRIPTION
We have duplicate functions which get the IPv6 link local address in both [libnetwork](https://github.com/projectcalico/libnetwork-plugin/blob/85335c32e63215f41f78d19065813dea2671a616/libnetwork/driver_plugin.py#L652) and in [libcalico](https://github.com/projectcalico/libcalico/blob/65ce4cc2db3a71db9ad47aefdf3b5bad8f89ea60/calico_containers/pycalico/netns.py#L212). This PR moves functionality for getting the IPv6 link local into a common utils function in pycalico. Follow up [PR# switches libnetwork to use this new libcalico function](https://github.com/projectcalico/libnetwork-plugin/pull/53)
