### PR TITLE
Update build to use jessie and add separate wheezy build container

### DIFF
--- a/Dockerfile.build_wheezy
+++ b/Dockerfile.build_wheezy
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM python:2.7.12
+
+# The wheezy build container is used to build calicoctl with older versions
+# of glibc (2.13).
+FROM python:2.7.12-wheezy
 MAINTAINER Tom Denham <tom@projectcalico.org>
 
 WORKDIR /code/

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ update-frozen:
 	docker run --rm calico/build pip freeze | grep -v pycalico > build-requirements-frozen.txt
 
 calicobuild.created: $(BUILD_FILES) $(PYCALICO)
-	docker build -t calico/build .
+	docker build -t calico/build:latest .
+	docker build -f Dockerfile.build_wheezy -t calico/build:latest-wheezy .
 	touch calicobuild.created
 
 dist/pycalico-$(WHEEL_VERSION)-py2-none-any.whl: $(PYCALICO)


### PR DESCRIPTION
Update calico/build to use jessie, add a new wheezy build container (for building older versions of calicoctl)
