### PR TITLE
Move Default ASN Into Private 16 Bit Range.

### DIFF
--- a/calico_containers/pycalico/datastore.py
+++ b/calico_containers/pycalico/datastore.py
@@ -92,7 +92,7 @@ LOG_FILE_PATH_PATH = CONFIG_PATH + "LogFilePath"
 FELIX_REPORTING_INTERVAL_PATH = CONFIG_PATH + "ReportingIntervalSecs"
 
 # The default node AS number.
-DEFAULT_AS_NUM = 64511
+DEFAULT_AS_NUM = 64512
 
 # The default node mesh configuration.
 DEFAULT_NODE_MESH = {"enabled": True}

--- a/calico_containers/tests/unit/test_datastore.py
+++ b/calico_containers/tests/unit/test_datastore.py
@@ -588,7 +588,7 @@ class TestDatastoreClient(unittest.TestCase):
                            call(IPV4_POOLS_PATH, None, dir=True),
                            call(IPAM_V6_PATH, None, dir=True),
                            call(IPV6_POOLS_PATH, None, dir=True),
-                           call(BGP_NODE_DEF_AS_PATH, "64511"),
+                           call(BGP_NODE_DEF_AS_PATH, "64512"),
                            call(BGP_NODE_MESH_PATH, json.dumps({"enabled": True})),
                            call(log_file_path, "none"),
                            call(log_screen_path, "info"),
@@ -627,7 +627,7 @@ class TestDatastoreClient(unittest.TestCase):
                            call(IPV4_POOLS_PATH, None, dir=True),
                            call(IPAM_V6_PATH, None, dir=True),
                            call(IPV6_POOLS_PATH, None, dir=True),
-                           call(BGP_NODE_DEF_AS_PATH, "64511"),
+                           call(BGP_NODE_DEF_AS_PATH, "64512"),
                            call(BGP_NODE_MESH_PATH, json.dumps({"enabled": True})),
                            call(log_file_path, "none"),
                            call(log_screen_path, "info"),
@@ -1695,7 +1695,7 @@ class TestDatastoreClient(unittest.TestCase):
         :return: None.
         """
         self.etcd_client.read.side_effect = EtcdKeyNotFound()
-        assert_equal(self.datastore.get_default_node_as(), "64511")
+        assert_equal(self.datastore.get_default_node_as(), "64512")
 
     def test_get_hosts_data(self):
         """


### PR DESCRIPTION
This should help prevent any conflicts if any of these private clusters were to
become accessible directly from the internet.

Should resolve ticket #140.
