### PR TITLE
Add new requirements for correct SAN parsing by urllib3

### DIFF
--- a/Dockerfile.calico_test
+++ b/Dockerfile.calico_test
@@ -42,7 +42,7 @@ MAINTAINER Tom Denham <tom@projectcalico.org>
 # We install glibc onto the official docker image (instead of adding docker to 
 # the libc image) since glibc installs are more constant than the 
 # docker-in-docker installation and configuration.
-RUN apk add --update python python-dev py-pip py-setuptools \
+RUN apk add --update python python-dev py-pip py-setuptools openssl-dev libffi-dev \
         git musl-dev gcc \
         iptables ip6tables iproute2 iputils ipset curl && \
         curl -o glibc.apk -L "https://github.com/andyshinn/alpine-pkg-glibc/releases/download/2.23-r1/glibc-2.23-r1.apk" && \

--- a/build-requirements-frozen.txt
+++ b/build-requirements-frozen.txt
@@ -12,6 +12,6 @@ PyYAML==3.11
 requests==2.9.1
 six==1.10.0
 subprocess32==3.2.7
-urllib3==1.14
+urllib3==1.18
 virtualenv==12.1.1
 websocket-client==0.35.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 netaddr
 python-etcd
 subprocess32
+pyopenssl 
+ndg-httpsclient
+pyasn1

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,8 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['netaddr', 'python-etcd>=0.4.3', 'subprocess32'],
+    install_requires=['netaddr', 'python-etcd>=0.4.3', 'subprocess32',
+                      'pyopenssl', 'ndg-httpsclient', 'pyasn1'],
     dependency_links=[
         "git+https://github.com/jplana/python-etcd.git@0d0145f5e835aa032c97a0a5e09c4c68b7a03f66#egg=python-etcd-0.4.3"
     ]


### PR DESCRIPTION
Upgrades to urllib3, which includes IP SAN support.

Also, installs deps required for the IP SAN support to work properly.  See here: https://stackoverflow.com/questions/18578439/using-requests-with-tls-doesnt-give-sni-support/18579484#18579484
