### PR TITLE
Don't overwrite DefaultEndpointToHostAction when running calicoctl node if it was already set

### DIFF
--- a/calico_containers/pycalico/datastore.py
+++ b/calico_containers/pycalico/datastore.py
@@ -400,9 +400,10 @@ class DatastoreClient(object):
         # not otherwise firewalled by the host administrator or profiles).
         # This is important for Mesos, where the containerized executor process
         # needs to exchange messages with the Mesos Slave process running on
-        # the host.
-        self.set_per_host_config(hostname, "DefaultEndpointToHostAction",
-                                 "RETURN")
+        # the host.  Don't overwrite the value if it's already present.
+        if self.get_per_host_config(hostname, "DefaultEndpointToHostAction") is None:
+            self.set_per_host_config(hostname, "DefaultEndpointToHostAction",
+                                    "RETURN")
 
         # Flag that the host is created.
         self.set_per_host_config(hostname, "marker", "created")

--- a/calico_containers/tests/unit/test_datastore.py
+++ b/calico_containers/tests/unit/test_datastore.py
@@ -953,6 +953,9 @@ class TestDatastoreClient(unittest.TestCase):
             result = Mock(spec=EtcdResult)
             if path == TEST_HOST_PATH + "/workload":
                 return result
+            elif path == TEST_HOST_PATH + "/config/DefaultEndpointToHostAction":
+                result.value = "RETURN"
+                return result
             else:
                 assert False
 
@@ -966,14 +969,11 @@ class TestDatastoreClient(unittest.TestCase):
                            call(TEST_BGP_HOST_IPV4_PATH, ipv4),
                            call(TEST_BGP_HOST_IPV6_PATH, ipv6),
                            call(TEST_BGP_HOST_AS_PATH, bgp_as),
-                           call(TEST_HOST_PATH +
-                                "/config/DefaultEndpointToHostAction",
-                                "RETURN"),
                            call(TEST_HOST_PATH + "/config/marker",
                                 "created")]
         self.etcd_client.write.assert_has_calls(expected_writes,
                                                 any_order=True)
-        assert_equal(self.etcd_client.write.call_count, 6)
+        assert_equal(self.etcd_client.write.call_count, 5)
 
     def test_create_host_mainline(self):
         """
@@ -983,6 +983,8 @@ class TestDatastoreClient(unittest.TestCase):
         """
         def mock_read(path):
             if path == CALICO_V_PATH + "/host/TEST_HOST/workload":
+                raise EtcdKeyNotFound()
+            elif path == TEST_HOST_PATH + "/config/DefaultEndpointToHostAction":
                 raise EtcdKeyNotFound()
             else:
                 assert False


### PR DESCRIPTION
Fixes https://github.com/projectcalico/calico-containers/issues/1190

I've left the overwrite other config code in place for now: it shouldn't cause problems because they can be specified when running `calicoctl node`.
