### PR TITLE
Allow to customize docker image name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,16 @@
 .PHONY: all test test_image ut ut-circle clean setup-env
 
-SRCDIR=calico_containers
-PYCALICO=$(wildcard $(SRCDIR)/pycalico/*.py)
+###############################################################################
+# Common build variables
+# Path to the sources.
+# Default value: directory with Makefile
+SOURCE_DIR?=$(dir $(lastword $(MAKEFILE_LIST)))
+SOURCE_DIR:=$(abspath $(SOURCE_DIR))
+
+BUILD_CONTAINER_NAME?=calico/build:latest
+TEST_CONTAINER_NAME?=calico/test:latest
+
+PYCALICO=$(wildcard $(SOURCE_DIR)/calico_containers/pycalico/*.py)
 BUILD_FILES=Dockerfile build-requirements-frozen.txt
 
 TEST_CONTAINER_FILES=$(shell find calico_test/ -type f ! -name '*.created')
@@ -19,12 +28,12 @@ calico/test: calico_test.created
 
 update-frozen:
 	cp build-requirements.txt build-requirements-frozen.txt
-	docker build -t calico/build .
-	docker run --rm calico/build pip freeze | grep -v pycalico > build-requirements-frozen.txt
+	docker build -t $(BUILD_CONTAINER_NAME) .
+	docker run --rm $(BUILD_CONTAINER_NAME) pip freeze | grep -v pycalico > build-requirements-frozen.txt
 
 calicobuild.created: $(BUILD_FILES) $(PYCALICO)
-	docker build -t calico/build:latest .
-	docker build -f Dockerfile.build_wheezy -t calico/build:latest-wheezy .
+	docker build -t $(BUILD_CONTAINER_NAME) .
+	docker build -f Dockerfile.build_wheezy -t $(BUILD_CONTAINER_NAME)-wheezy .
 	touch calicobuild.created
 
 dist/pycalico-$(WHEEL_VERSION)-py2-none-any.whl: $(PYCALICO)
@@ -32,24 +41,24 @@ dist/pycalico-$(WHEEL_VERSION)-py2-none-any.whl: $(PYCALICO)
 	chmod 777 dist
 	python setup.py bdist_wheel
 
-calico_test.created: $(TEST_CONTAINER_FILES)                                             
-	docker build -f Dockerfile.calico_test -t calico/test:latest .
-	touch calico_test.created   
+calico_test.created: $(TEST_CONTAINER_FILES)
+	docker build -f Dockerfile.calico_test -t $(TEST_CONTAINER_NAME) .
+	touch calico_test.created
 
 ut: calico_test.created
-	docker run --rm -v `pwd`/calico_containers:/code calico/test \
+	docker run --rm -v $(SOURCE_DIR)/calico_containers:/code $(TEST_CONTAINER_NAME) \
                 nosetests tests/unit  -c nose.cfg
 
 
-ut-circle: calico_test.created 
+ut-circle: calico_test.created
 	# Test this locally using CIRCLE_TEST_REPORTS=/tmp COVERALLS_REPO_TOKEN=bad make ut-circle
 	# Can't use --rm on circle
 	# Circle also requires extra options for reporting.
 	docker run \
-        -v `pwd`:/code \
+        -v $(SOURCE_DIR):/code \
         -v $(CIRCLE_TEST_REPORTS):/circle_output \
         -e COVERALLS_REPO_TOKEN=$(COVERALLS_REPO_TOKEN) \
-        calico/test \
+        $(TEST_CONTAINER_NAME) \
         sh -c '\
         cd calico_containers; nosetests tests/unit -c nose.cfg \
         --with-xunit --xunit-file=/circle_output/output.xml; RC=$$?;\
@@ -62,8 +71,8 @@ clean:
 	-rm -rf build
 	-rm -rf calico_containers/pycalico.egg-info/
 	-docker rm -f calico-build
-	-docker rmi calico/build
-	-docker rmi calico/test
+	-docker rmi $(BUILD_CONTAINER_NAME) $(BUILD_CONTAINER_NAME)-wheezy
+	-docker rmi $(TEST_CONTAINER_NAME)
 
 setup-env:
 	virtualenv venv


### PR DESCRIPTION
1. During build process there might be situation when one needs to
   assign custom docker names to calico/build and calico/test images,
   e.g. to push to some custom repos, etc:
   
   make calico/build BUILD_CONTAINER_NAME=mycustomrepo/calico/build:customTag

This change implements such functionality.
1. Also variable SOURCE_DIR added, which points to the root of the
   project and allows to get rid of `pwd`
2. Clean target should also remove calico/build:latest-wheezy image
3. A little bit clean-up on trailing spaces
