### PR TITLE
Fix KeyError: 'affinity'

### DIFF
--- a/calico_containers/pycalico/block.py
+++ b/calico_containers/pycalico/block.py
@@ -147,7 +147,7 @@ class AllocationBlock(object):
         # Parse out the host.  For now, it's in the form host:<host id>.  An
         # empty host ID is converted to None to indicate the block has no
         # specific host affinity.
-        affinity = json_dict[AllocationBlock.AFFINITY]
+        affinity = json_dict.get(AllocationBlock.AFFINITY)
         if not affinity:
             host_affinity = None
         else:


### PR DESCRIPTION
When etcd doesn't store key "affinity", command "calicoctl node remove"
fails with KeyError. This change uses dict.get("affinity") instead
dict["affinity"] to avoid keyrror.

Fixes projectcalico/calico-containers#1279