### PR TITLE
Improve ST diags

### DIFF
--- a/calico_test/tests/st/test_base.py
+++ b/calico_test/tests/st/test_base.py
@@ -21,7 +21,7 @@ from unittest import TestCase
 from deepdiff import DeepDiff
 from multiprocessing.dummy import Pool as ThreadPool
 
-from tests.st.utils.utils import (get_ip, ETCD_SCHEME, ETCD_CA, ETCD_CERT,
+from tests.st.utils.utils import (TestWithHooks, get_ip, ETCD_SCHEME, ETCD_CA, ETCD_CERT,
                                   ETCD_KEY, debug_failures, ETCD_HOSTNAME_SSL)
 
 HOST_IPV6 = get_ip(v6=True)
@@ -35,7 +35,7 @@ sh_logger = logging.getLogger("sh")
 sh_logger.setLevel(level=logging.CRITICAL)
 
 
-class TestBase(TestCase):
+class TestBase(TestWithHooks):
     """
     Base class for test-wide methods.
     """

--- a/calico_test/tests/st/test_base.py
+++ b/calico_test/tests/st/test_base.py
@@ -40,19 +40,20 @@ class TestBase(TestWithHooks):
     Base class for test-wide methods.
     """
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         """
-        Clean up before every test.
+        Clean up before every testrun.
         """
-        self.ip = HOST_IPV4
+        cls.ip = HOST_IPV4
 
         # Delete /calico if it exists. This ensures each test has an empty data
         # store at start of day.
-        self.curl_etcd("calico", options=["-XDELETE"])
+        cls.curl_etcd("calico", options=["-XDELETE"])
 
         # Disable Usage Reporting to usage.projectcalico.org
         # We want to avoid polluting analytics data with unit test noise
-        self.curl_etcd("calico/v1/config/UsageReportingEnabled",
+        cls.curl_etcd("calico/v1/config/UsageReportingEnabled",
                        options=["-XPUT -d value=False"])
 
         # Log a newline to ensure that the first log appears on its own line.
@@ -213,7 +214,8 @@ class TestBase(TestWithHooks):
         assert False not in results, ("Connectivity check error!\r\n"
                                       "Results:\r\n %s\r\n" % diagstring)
 
-    def curl_etcd(self, path, options=None, recursive=True):
+    @staticmethod
+    def curl_etcd(path, options=None, recursive=True):
         """
         Perform a curl to etcd, returning JSON decoded response.
         :param path:  The key path to query
@@ -234,7 +236,7 @@ class TestBase(TestWithHooks):
         else:
             rc = subprocess.check_output(
                 "curl -sL http://%s:2379/v2/keys/%s?recursive=%s %s"
-                % (self.ip, path, str(recursive).lower(), " ".join(options)),
+                % (HOST_IPV4, path, str(recursive).lower(), " ".join(options)),
                 shell=True)
 
         return json.loads(rc.strip())

--- a/calico_test/tests/st/utils/docker_host.py
+++ b/calico_test/tests/st/utils/docker_host.py
@@ -418,4 +418,4 @@ class DockerHost(object):
         :param data: string, the data to put inthe file
         :return: Return code of execute operation.
         """
-        return self.execute("cat << EOF > %s\n%s" % (filename, data))
+        return self.execute("cat << EOF > %s\n%s\nEOF\n" % (filename, data))

--- a/calico_test/tests/st/utils/docker_host.py
+++ b/calico_test/tests/st/utils/docker_host.py
@@ -19,6 +19,8 @@ from functools import partial
 
 from utils import get_ip, log_and_run, retry_until_success, ETCD_SCHEME, \
     ETCD_CA, ETCD_KEY, ETCD_CERT, ETCD_HOSTNAME_SSL
+from tests.st.utils.exceptions import CommandExecError
+
 from workload import Workload
 from network import DockerNetwork
 
@@ -367,6 +369,13 @@ class DockerHost(object):
         :param subnet: The subnet IP pool to assign IPs from.
         :return: A DockerNetwork object.
         """
+        try:
+            self.execute("docker network inspect %s" % name)
+            # Network exists - delete it
+            self.execute("docker network rm " + name)
+        except CommandExecError:
+            # Network didn't exist, no problem.
+            pass
         nw = DockerNetwork(self, name, driver=driver, ipam_driver=ipam_driver,
                            subnet=subnet)
 

--- a/calico_test/tests/st/utils/utils.py
+++ b/calico_test/tests/st/utils/utils.py
@@ -133,13 +133,30 @@ class TestWithHooks(unittest.TestCase):
 
     @classmethod
     def get_diags(cls):
+        logfiles = [
+            "/var/log/calico/bird/current",
+            "/var/log/calico/bird6/current",
+            "/var/log/calico/confd/current",
+            "/var/log/calico/felix/current",
+            "/var/log/calico/libnetwork/current",
+        ]
         if cls.hosts:
             for host in cls.hosts:
                 if host.dind:
-                    logger.debug("Docker logs from %s (%s):\r\n%s",
-                                 host.name,
-                                 host.ip,
-                                 host.execute("docker logs calico-node"))
+                    try:
+                        logger.debug("Docker logs from %s (%s):\r\n%s",
+                                     host.name,
+                                     host.ip,
+                                     host.execute("docker logs calico-node"))
+                    except CommandExecError:
+                        logger.info("Error getting docker logs from calico-node")
+                for logfile in logfiles:
+                    try:
+                        host.execute("cat %s" % logfile)
+                    except CommandExecError:
+                        logger.info("*" * 80)
+                        logger.info("Getting logs from %s", logfile)
+                        logger.info("Error getting %s", logfile)
 
 
 def get_ip(v6=False):

--- a/calico_test/tests/st/utils/utils.py
+++ b/calico_test/tests/st/utils/utils.py
@@ -133,30 +133,7 @@ class TestWithHooks(unittest.TestCase):
 
     @classmethod
     def get_diags(cls):
-        logfiles = [
-            "/var/log/calico/bird/current",
-            "/var/log/calico/bird6/current",
-            "/var/log/calico/confd/current",
-            "/var/log/calico/felix/current",
-            "/var/log/calico/libnetwork/current",
-        ]
-        if cls.hosts:
-            for host in cls.hosts:
-                if host.dind:
-                    try:
-                        logger.debug("Docker logs from %s (%s):\r\n%s",
-                                     host.name,
-                                     host.ip,
-                                     host.execute("docker logs calico-node"))
-                    except CommandExecError:
-                        logger.info("Error getting docker logs from calico-node")
-                for logfile in logfiles:
-                    try:
-                        host.execute("cat %s" % logfile)
-                    except CommandExecError:
-                        logger.info("*" * 80)
-                        logger.info("Getting logs from %s", logfile)
-                        logger.info("Error getting %s", logfile)
+        logger.debug("You should be overriding get_diags!")
 
 
 def get_ip(v6=False):

--- a/calico_test/tests/st/utils/utils.py
+++ b/calico_test/tests/st/utils/utils.py
@@ -104,7 +104,7 @@ class ResultsWithHooks(type):
     """
     def __new__(cls, name, bases, dct):
         for attr, value in dct.iteritems():
-            if attr.startswith("test_"):
+            if attr.startswith("test_") and hasattr(value, '__module__'):
                 dct[attr] = decorate_with_hooks(value)
         return super(ResultsWithHooks, cls).__new__(cls, name, bases, dct)
 
@@ -128,7 +128,18 @@ class TestWithHooks(unittest.TestCase):
         """
         The test raised an exception.
         """
+        cls.get_diags()
         logger.info("Test failed.")
+
+    @classmethod
+    def get_diags(cls):
+        if cls.hosts:
+            for host in cls.hosts:
+                if host.dind:
+                    logger.debug("Docker logs from %s (%s):\r\n%s",
+                                 host.name,
+                                 host.ip,
+                                 host.execute("docker logs calico-node"))
 
 
 def get_ip(v6=False):


### PR DESCRIPTION
Output more diags for failures and make the output easier to read with banners for key moments in the test in order to address https://github.com/projectcalico/calico-containers/issues/1270

Also move the code which wiped etcd after every test to run once per testClass instead to allow groups of tests to setup shared test setup.
