### PR TITLE
Stop wrapped() decorator squelching stack traces of exceptions hit by test scripts

### DIFF
--- a/calico_test/tests/st/utils/utils.py
+++ b/calico_test/tests/st/utils/utils.py
@@ -129,7 +129,7 @@ def debug_failures(fn):
                              % e.message)
                 pdb.set_trace()
             else:
-                raise e
+                raise
 
     return wrapped
 


### PR DESCRIPTION
`raise e` creates a new exception; wiping out the previous stack trace.