### PR TITLE
Modify default log format for container tests

### DIFF
--- a/calico_test/tests/st/test_base.py
+++ b/calico_test/tests/st/test_base.py
@@ -27,8 +27,9 @@ from tests.st.utils.utils import (get_ip, ETCD_SCHEME, ETCD_CA, ETCD_CERT,
 
 HOST_IPV6 = get_ip(v6=True)
 HOST_IPV4 = get_ip()
-FORMAT_STRING = '%(asctime)s [%(levelname)s][%(process)s/%(thread)x] %(name)s %(lineno)d: %(message)s'
-logging.basicConfig(level=logging.DEBUG, format=FORMAT_STRING)
+FORMAT_STRING = '# %(asctime)s [%(levelname)s][%(process)s/%(thread)x] ' \
+                '%(name)s %(lineno)d: %(message)s'
+logging.basicConfig(level=logging.DEBUG, format=FORMAT_STRING, datefmt='%H:%M:%S')
 logger = logging.getLogger(__name__)
 
 # Disable spammy logging from the sh module

--- a/calico_test/tests/st/test_base.py
+++ b/calico_test/tests/st/test_base.py
@@ -29,7 +29,7 @@ HOST_IPV6 = get_ip(v6=True)
 HOST_IPV4 = get_ip()
 FORMAT_STRING = '# %(asctime)s [%(levelname)s][%(process)s/%(thread)x] ' \
                 '%(name)s %(lineno)d: %(message)s'
-logging.basicConfig(level=logging.DEBUG, format=FORMAT_STRING, datefmt='%H:%M:%S')
+logging.basicConfig(level=logging.DEBUG, format=FORMAT_STRING)
 logger = logging.getLogger(__name__)
 
 # Disable spammy logging from the sh module

--- a/calico_test/tests/st/test_base.py
+++ b/calico_test/tests/st/test_base.py
@@ -27,8 +27,8 @@ from tests.st.utils.utils import (get_ip, ETCD_SCHEME, ETCD_CA, ETCD_CERT,
 
 HOST_IPV6 = get_ip(v6=True)
 HOST_IPV4 = get_ip()
-
-logging.basicConfig(level=logging.DEBUG, format="%(message)s")
+FORMAT_STRING = '%(asctime)s [%(levelname)s][%(process)s/%(thread)x] %(name)s %(lineno)d: %(message)s'
+logging.basicConfig(level=logging.DEBUG, format=FORMAT_STRING)
 logger = logging.getLogger(__name__)
 
 # Disable spammy logging from the sh module


### PR DESCRIPTION
Format has been taken from the Felix log formatter (@fasaxc recommended it). 

Example output with the new formatter:
```
2017-01-19 12:49:18,801 [INFO][26158/140043457387184] tests.st.utils.utils 73:   # 64 bytes from 192.168.141.192: seq=0 ttl=64 time=0.145 ms
2017-01-19 12:49:18,802 [INFO][26158/140043457387184] tests.st.utils.utils 73:   # 
2017-01-19 12:49:18,803 [INFO][26158/140043457387184] tests.st.utils.utils 73:   # --- 192.168.141.192 ping statistics ---
2017-01-19 12:49:18,803 [INFO][26158/140043457387184] tests.st.utils.utils 73:   # 1 packets transmitted, 1 packets received, 0% packet loss
2017-01-19 12:49:18,804 [INFO][26158/140043457387184] tests.st.utils.utils 73:   # round-trip min/avg/max = 0.145/0.14
```

Timestamp should allow us to do things like profiling tests (seeing where all the time is going).  