### PR TITLE
Rev requests and urllib3.

### DIFF
--- a/build-requirements-frozen.txt
+++ b/build-requirements-frozen.txt
@@ -9,9 +9,9 @@ PyInstaller==3.1.1
 git+https://github.com/jplana/python-etcd.git@0d0145f5e835aa032c97a0a5e09c4c68b7a03f66
 prometheus_client==0.0.13
 PyYAML==3.11
-requests==2.9.1
+requests==2.13.0
 six==1.10.0
 subprocess32==3.2.7
-urllib3==1.18
+urllib3==1.20.0
 virtualenv==12.1.1
 websocket-client==0.35.0


### PR DESCRIPTION
- Rev urllib3 to latest (1.20.0) to pick up security fixes.
- Rev requests to 2.13.0 pick up newer vendored version of urllib3; includes the security fixes above as well as support for IP SANs. Should fix https://github.com/projectcalico/k8s-policy/issues/69.

This passed the policy agent STs but I don't think they test TLS.  Since the fix targets TLS, feels like we should test that before merging.  Will follow up on slack to figure out the best way to do that.