### PR TITLE
Remove cast to int for port:port values

### DIFF
--- a/calico_containers/pycalico/datastore_datatypes.py
+++ b/calico_containers/pycalico/datastore_datatypes.py
@@ -485,9 +485,9 @@ class Rule(dict):
 
         # Convert ports to integers.
         if "dst_ports" in json_dict:
-            json_dict["dst_ports"] = [int(p) for p in json_dict["dst_ports"]]
+            json_dict["dst_ports"] = [p for p in json_dict["dst_ports"]]
         if "src_ports" in json_dict:
-            json_dict["src_ports"] = [int(p) for p in json_dict["src_ports"]]
+            json_dict["src_ports"] = [p for p in json_dict["src_ports"]]
 
         return json_dict
 


### PR DESCRIPTION
## Description
Reverted behavior which casts ports to ints before assignment.

## Todos
- [ ] Unit tests (full coverage) - NOT REQUIRED (parsing should be covered by `TestRule:test_pprint`)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done - NOT REQUIRED
- [ ] Documentation - NOT REQUIRED
- [ ] Backport - NOT REQUIRED
