### PR TITLE
Issue 158: remove cast to int for 'NNNN:NNNN' port range values

### DIFF
--- a/calico_containers/pycalico/datastore_datatypes.py
+++ b/calico_containers/pycalico/datastore_datatypes.py
@@ -485,9 +485,9 @@ class Rule(dict):
 
         # Convert ports to integers.
         if "dst_ports" in json_dict:
-            json_dict["dst_ports"] = [int(p) for p in json_dict["dst_ports"]]
+            json_dict["dst_ports"] = [p for p in json_dict["dst_ports"]]
         if "src_ports" in json_dict:
-            json_dict["src_ports"] = [int(p) for p in json_dict["src_ports"]]
+            json_dict["src_ports"] = [p for p in json_dict["src_ports"]]
 
         return json_dict
 


### PR DESCRIPTION
## Description
Referencing https://github.com/projectcalico/libcalico/issues/158; remove cast to `int(p)` for port range values specified as `NNNN:NNNN`.

## Todos
- [ ] Unit tests (full coverage) - _this case is already covered_
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
